### PR TITLE
Moved configuration to be a sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+conf/orchestrator.conf.json
+

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,6 @@ for f in $(find . -name "*.go"); do go fmt $f; done
 
 rsync -av ./resources $release_files_dir/usr/local/orchestrator/
 rsync -av ./conf $release_files_dir/usr/local/orchestrator/
-for f in $release_files_dir/usr/local/orchestrator/conf/*; do mv $f $f.sample; done
 cp etc/init.d/orchestrator.bash $release_files_dir/etc/init.d/orchestrator
 chmod +x $release_files_dir/etc/init.d/orchestrator
 

--- a/conf/orchestrator.conf.json.sample
+++ b/conf/orchestrator.conf.json.sample
@@ -24,7 +24,7 @@
   "RejectHostnameResolvePattern": "",
   "UnseenInstanceForgetHours": 240,
   "CandidateInstanceExpireMinutes": 60,
-  "SnapshotTopologiesIntervalHours": 0,
+  "SnapshotTopologiesIntervalHours": 24,
   "ReasonableReplicationLagSeconds": 10,
   "VerifyReplicationFilters": false,
   "ReasonableMaintenanceReplicationLagSeconds": 20,


### PR DESCRIPTION
This way when you build locally to develop, you don't need to use the
build script which also does packaging. You can just call the following:

    $ cp conf/orchestrator.conf.json.sample conf/orchestrator.conf.json
    $ # modify your configuration here
    $ go build -o orchestrator go/cmd/orchestrator/main.go
    $ ./orchestrator ...

Otherwise you'd have to fight with the default configuration if you want
to get something working locally that's different from the default
configuration.

For my vagrant local development work I rely on this and then put
orchestrator.conf.json into /etc on the virtual machine so it will load
there first, which still retain the ability to customize further.

