### PR TITLE
Brianip/configure agent api port

### DIFF
--- a/conf/orchestrator.conf.json.sample
+++ b/conf/orchestrator.conf.json.sample
@@ -1,6 +1,7 @@
 {
   "Debug": true,
   "ListenAddress": ":3000",
+  "AgentsServerPort": ":3001",
   "MySQLTopologyUser": "msandbox",
   "MySQLTopologyPassword": "msandbox",
   "MySQLTopologyCredentialsConfigFile": "",

--- a/go/app/http.go
+++ b/go/app/http.go
@@ -18,6 +18,12 @@
 package app
 
 import (
+	nethttp "net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
 	"github.com/go-martini/martini"
 	"github.com/martini-contrib/auth"
 	"github.com/martini-contrib/gzip"
@@ -27,11 +33,6 @@ import (
 	"github.com/outbrain/orchestrator/go/http"
 	"github.com/outbrain/orchestrator/go/inst"
 	"github.com/outbrain/orchestrator/go/logic"
-	nethttp "net/http"
-	"os"
-	"os/signal"
-	"strings"
-	"syscall"
 )
 
 // acceptSignals registers for OS signals
@@ -138,11 +139,11 @@ func agentsHttp() {
 	// Serve
 	if config.Config.AgentsUseSSL {
 		log.Info("Serving via SSL")
-		err := nethttp.ListenAndServeTLS(":3001", config.Config.SSLCertFile, config.Config.SSLPrivateKeyFile, m)
+		err := nethttp.ListenAndServeTLS(config.Config.AgentsServerPort, config.Config.SSLCertFile, config.Config.SSLPrivateKeyFile, m)
 		if err != nil {
 			log.Fatale(err)
 		}
 	} else {
-		nethttp.ListenAndServe(":3001", m)
+		nethttp.ListenAndServe(config.Config.AgentsServerPort, m)
 	}
 }

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -17,9 +17,10 @@
 package config
 
 import (
-	"code.google.com/p/gcfg"
 	"encoding/json"
 	"os"
+
+	"code.google.com/p/gcfg"
 
 	"github.com/outbrain/golib/log"
 )
@@ -30,6 +31,7 @@ import (
 type Configuration struct {
 	Debug                                      bool // set debug mode (similar to --debug option)
 	ListenAddress                              string
+	AgentsServerPort                           string // port orchestrator agents talk back to
 	MySQLTopologyUser                          string
 	MySQLTopologyPassword                      string // my.cnf style configuration file from where to pick credentials. Expecting `user`, `password` under `[client]` section
 	MySQLTopologyCredentialsConfigFile         string
@@ -114,6 +116,7 @@ func NewConfiguration() *Configuration {
 	return &Configuration{
 		Debug:                                      false,
 		ListenAddress:                              ":3000",
+		AgentsServerPort:                           ":3001",
 		MySQLOrchestratorPort:                      3306,
 		MySQLTopologyMaxPoolConnections:            3,
 		MySQLConnectTimeoutSeconds:                 5,


### PR DESCRIPTION
Allow for port that orchestrator agents talk back on to be configurable. Defaults still set to :3001. PR to be made on orchestrator-agent to make corresponding changes.