### PR TITLE
SSL and Mutual TLS support

### DIFF
--- a/go/agent/agent_dao.go
+++ b/go/agent/agent_dao.go
@@ -43,7 +43,7 @@ func dialTimeout(network, addr string) (net.Conn, error) {
 }
 
 var httpTransport = &http.Transport{
-	TLSClientConfig: &tls.Config{InsecureSkipVerify: config.Config.SSLSkipVerify},
+	TLSClientConfig: &tls.Config{InsecureSkipVerify: config.Config.AgentSSLSkipVerify},
 	Dial:            dialTimeout,
 	ResponseHeaderTimeout: httpTimeout,
 }

--- a/go/app/http.go
+++ b/go/app/http.go
@@ -126,15 +126,15 @@ func standardHttp(discovery bool) {
 		if err != nil {
 			log.Fatale(err)
 		}
-		if err := http.AppendKeyPair(tlsConfig, config.Config.SSLCertFile, config.Config.SSLPrivateKeyFile); err != nil {
+		if err = http.AppendKeyPair(tlsConfig, config.Config.SSLCertFile, config.Config.SSLPrivateKeyFile); err != nil {
 			log.Fatale(err)
 		}
-		if err := http.ListenAndServeTLS(config.Config.ListenAddress, m, tlsConfig); err != nil {
+		if err = http.ListenAndServeTLS(config.Config.ListenAddress, m, tlsConfig); err != nil {
 			log.Fatale(err)
 		}
 	} else {
 		log.Info("Starting HTTP listener")
-		if err := nethttp.ListenAndServe(config.Config.ListenAddress, m); err != nil {
+		if err = nethttp.ListenAndServe(config.Config.ListenAddress, m); err != nil {
 			log.Fatale(err)
 		}
 	}

--- a/go/app/http.go
+++ b/go/app/http.go
@@ -105,23 +105,40 @@ func standardHttp(discovery bool) {
 		HTMLContentType: "text/html",
 	}))
 	m.Use(martini.Static("resources/public"))
+	m.Use(http.VerifyOUs())
 
 	inst.SetMaintenanceOwner(logic.ThisHostname)
 
-	log.Info("Starting HTTP")
-
 	if discovery {
+		log.Info("Starting Discovery")
 		go logic.ContinuousDiscovery()
 	}
 	inst.ReadClusterAliases()
 
+	log.Info("Registering endpoints")
 	http.API.RegisterRequests(m)
 	http.Web.RegisterRequests(m)
 
 	// Serve
-	if err := nethttp.ListenAndServe(config.Config.ListenAddress, m); err != nil {
-		log.Fatale(err)
+	if config.Config.UseSSL {
+		log.Info("Starting HTTPS listener")
+		tlsConfig, err := http.NewTLSConfig(config.Config.SSLCAFile, config.Config.UseMutualTLS)
+		if err != nil {
+			log.Fatale(err)
+		}
+		if err := http.AppendKeyPair(tlsConfig, config.Config.SSLCertFile, config.Config.SSLPrivateKeyFile); err != nil {
+			log.Fatale(err)
+		}
+		if err := http.ListenAndServeTLS(config.Config.ListenAddress, m, tlsConfig); err != nil {
+			log.Fatale(err)
+		}
+	} else {
+		log.Info("Starting HTTP listener")
+		if err := nethttp.ListenAndServe(config.Config.ListenAddress, m); err != nil {
+			log.Fatale(err)
+		}
 	}
+	log.Info("Web server started")
 }
 
 // agentsHttp startes serving agents API requests
@@ -139,7 +156,7 @@ func agentsHttp() {
 	// Serve
 	if config.Config.AgentsUseSSL {
 		log.Info("Serving via SSL")
-		err := nethttp.ListenAndServeTLS(config.Config.AgentsServerPort, config.Config.SSLCertFile, config.Config.SSLPrivateKeyFile, m)
+		err := nethttp.ListenAndServeTLS(config.Config.AgentsServerPort, config.Config.AgentSSLCertFile, config.Config.AgentSSLPrivateKeyFile, m)
 		if err != nil {
 			log.Fatale(err)
 		}

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -85,9 +85,19 @@ type Configuration struct {
 	PromotionIgnoreHostnameFilters             []string          // Orchestrator will not promote slaves with hostname matching pattern (via -c recovery; for example, avoid promoting dev-dedicated machines)
 	ServeAgentsHttp                            bool              // Spawn another HTTP interface dedicated for orcehstrator-agent
 	AgentsUseSSL                               bool              // When "true" orchestrator will listen on agents port with SSL as well as connect to agents via SSL
+	AgentsUseMutualTLS                         bool              // When "true" Use mutual TLS for the server to agent communication
+	AgentSSLSkipVerify                         bool              // When using SSL for the Agent, should we ignore SSL certification error
+	AgentSSLPrivateKeyFile                     string            // Name of Agent SSL private key file, applies only when AgentsUseSSL = true
+	AgentSSLCertFile                           string            // Name of Agent SSL certification file, applies only when AgentsUseSSL = true
+	AgentSSLCAFile                             string            // Name of the Agent Certificate Authority file, applies only when AgentsUseSSL = true
+	AgentSSLValidOUs                           []string          // Valid organizational units when using mutual TLS to communicate with the agents
+	UseSSL                                     bool              // Use SSL on the server web port
+	UseMutualTLS                               bool              // When "true" Use mutual TLS for the server's web and API connections
 	SSLSkipVerify                              bool              // When using SSL, should we ignore SSL certification error
-	SSLPrivateKeyFile                          string            // Name of SSL private key file, applies only when AgentsUseSSL = true
-	SSLCertFile                                string            // Name of SSL certification file, applies only when AgentsUseSSL = true
+	SSLPrivateKeyFile                          string            // Name of SSL private key file, applies only when UseSSL = true
+	SSLCertFile                                string            // Name of SSL certification file, applies only when UseSSL = true
+	SSLCAFile                                  string            // Name of the Certificate Authority file, applies only when UseSSL = true
+	SSLValidOUs                                []string          // Valid organizational units when using mutual TLS
 	HttpTimeoutSeconds                         int               // Number of idle seconds before HTTP GET request times out (when accessing orchestrator-agent)
 	AgentPollMinutes                           uint              // Minutes between agent polling
 	UnseenAgentForgetHours                     uint              // Number of hours after which an unseen agent is forgotten
@@ -166,9 +176,19 @@ func NewConfiguration() *Configuration {
 		PromotionIgnoreHostnameFilters:             []string{},
 		ServeAgentsHttp:                            false,
 		AgentsUseSSL:                               false,
+		AgentsUseMutualTLS:                         false,
+		AgentSSLValidOUs:                           []string{},
+		AgentSSLSkipVerify:                         false,
+		AgentSSLPrivateKeyFile:                     "",
+		AgentSSLCertFile:                           "",
+		AgentSSLCAFile:                             "",
+		UseSSL:                                     false,
+		UseMutualTLS:                               false,
+		SSLValidOUs:                                []string{},
 		SSLSkipVerify:                              false,
 		SSLPrivateKeyFile:                          "",
 		SSLCertFile:                                "",
+		SSLCAFile:                                  "",
 		HttpTimeoutSeconds:                         60,
 		AgentPollMinutes:                           60,
 		UnseenAgentForgetHours:                     6,

--- a/go/http/ssl.go
+++ b/go/http/ssl.go
@@ -1,0 +1,111 @@
+package http
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io/ioutil"
+	nethttp "net/http"
+	"strings"
+
+	"github.com/go-martini/martini"
+	"github.com/outbrain/golib/log"
+	"github.com/outbrain/orchestrator/go/config"
+)
+
+// Determine if a string element is in a string array
+func HasString(elem string, arr []string) bool {
+	for _, s := range arr {
+		if s == elem {
+			return true
+		}
+	}
+	return false
+}
+
+// NewTLSConfig returns an initialized TLS configuration suitable for client
+// authentication. If caFile is non-empty, it will be loaded.
+func NewTLSConfig(caFile string, mutualTLS bool) (*tls.Config, error) {
+	var c tls.Config
+
+	// No sslv3 or tls 1.0
+	c.MinVersion = tls.VersionTLS10
+	c.MaxVersion = tls.VersionTLS12
+	c.PreferServerCipherSuites = true
+
+	if mutualTLS {
+		log.Info("MutualTLS requested, client certificates will be verified")
+		c.ClientAuth = tls.VerifyClientCertIfGiven
+	}
+	if caFile != "" {
+		data, err := ioutil.ReadFile(caFile)
+		if err != nil {
+			return &c, err
+		}
+		c.ClientCAs = x509.NewCertPool()
+		if !c.ClientCAs.AppendCertsFromPEM(data) {
+			return &c, errors.New("No certificates parsed")
+		}
+		log.Info("Read in CA file:", caFile)
+	}
+	c.BuildNameToCertificate()
+	return &c, nil
+}
+
+// Verify that the OU of the presented client certificate matches the list
+// of Valid OUs
+func Verify(r *nethttp.Request) error {
+	if r.TLS == nil {
+		return errors.New("no TLS")
+	}
+	for _, chain := range r.TLS.VerifiedChains {
+		s := chain[0].Subject.OrganizationalUnit
+		log.Debug("All OUs:", strings.Join(s, " "))
+		for _, ou := range s {
+			log.Debug("Client presented OU:", ou)
+			if HasString(ou, config.Config.SSLValidOUs) {
+				log.Debug("Found valid OU:", ou)
+				return nil
+			}
+		}
+	}
+	log.Error("No valid OUs found")
+	return errors.New("Invalid OU")
+}
+
+func VerifyOUs() martini.Handler {
+	return func(res nethttp.ResponseWriter, req *nethttp.Request, c martini.Context) {
+		if config.Config.UseMutualTLS {
+			log.Info("Verifying client OU")
+			if err := Verify(req); err != nil {
+				nethttp.Error(res, err.Error(), nethttp.StatusUnauthorized)
+			}
+		} else {
+			log.Debug("Mutual TLS disabled, skipping OU check")
+		}
+	}
+}
+
+// AppendKeyPair loads the given TLS key pair and appends it to
+// tlsConfig.Certificates.
+func AppendKeyPair(tlsConfig *tls.Config, certFile string, keyFile string) error {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+	tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
+	return nil
+}
+
+// ListenAndServeTLS acts identically to http.ListenAndServeTLS, except that it
+// expects TLS configuration.
+func ListenAndServeTLS(addr string, handler nethttp.Handler, tlsConfig *tls.Config) error {
+	if addr == "" {
+		addr = ":https"
+	}
+	l, err := tls.Listen("tcp", addr, tlsConfig)
+	if err != nil {
+		return err
+	}
+	return nethttp.Serve(l, handler)
+}

--- a/go/http/ssl.go
+++ b/go/http/ssl.go
@@ -73,6 +73,7 @@ func Verify(r *nethttp.Request) error {
 	return errors.New("Invalid OU")
 }
 
+// TODO: make this testable?
 func VerifyOUs() martini.Handler {
 	return func(res nethttp.ResponseWriter, req *nethttp.Request, c martini.Context) {
 		if config.Config.UseMutualTLS {
@@ -99,8 +100,11 @@ func AppendKeyPair(tlsConfig *tls.Config, certFile string, keyFile string) error
 
 // ListenAndServeTLS acts identically to http.ListenAndServeTLS, except that it
 // expects TLS configuration.
+// TODO: refactor so this is testable?
 func ListenAndServeTLS(addr string, handler nethttp.Handler, tlsConfig *tls.Config) error {
 	if addr == "" {
+		// On unix Listen calls getaddrinfo to parse the port, so named ports are fine as long
+		// as they exist in /etc/services
 		addr = ":https"
 	}
 	l, err := tls.Listen("tcp", addr, tlsConfig)

--- a/go/http/ssl_test.go
+++ b/go/http/ssl_test.go
@@ -1,0 +1,143 @@
+package http_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	nethttp "net/http"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/outbrain/orchestrator/go/config"
+	"github.com/outbrain/orchestrator/go/http"
+)
+
+func TestHasString(t *testing.T) {
+	elem := "foo"
+	a1 := []string{"bar", "foo", "baz"}
+	a2 := []string{"bar", "fuu", "baz"}
+	good := http.HasString(elem, a1)
+	if !good {
+		t.Errorf("Didn't find %s in array %s", elem, strings.Join(a1, ", "))
+	}
+	bad := http.HasString(elem, a2)
+	if bad {
+		t.Errorf("Unexpectedly found %s in array %s", elem, strings.Join(a2, ", "))
+	}
+}
+
+// TODO: Build a fake CA and make sure it loads up
+func TestNewTLSConfig(t *testing.T) {
+	fakeCA := writeFakeFile(pemCertificate)
+	defer syscall.Unlink(fakeCA)
+
+	conf, err := http.NewTLSConfig(fakeCA, true)
+	if err != nil {
+		t.Errorf("Could not create new TLS config: %s", err)
+	}
+	if conf.ClientAuth != tls.VerifyClientCertIfGiven {
+		t.Errorf("Client certificate verification was not enabled")
+	}
+	if conf.ClientCAs == nil {
+		t.Errorf("ClientCA empty even though cert provided")
+	}
+
+	conf, err = http.NewTLSConfig("", false)
+	if err != nil {
+		t.Errorf("Could not create new TLS config: %s", err)
+	}
+	if conf.ClientAuth == tls.VerifyClientCertIfGiven {
+		t.Errorf("Client certificate verification was enabled unexpectedly")
+	}
+	if conf.ClientCAs != nil {
+		t.Errorf("Filling in ClientCA somehow without a cert")
+	}
+}
+
+func TestVerify(t *testing.T) {
+	req, err := nethttp.NewRequest("GET", "http://example.com/foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := http.Verify(req); err == nil {
+		t.Errorf("Did not fail on lack of TLS config")
+	}
+
+	pemBlock, _ := pem.Decode([]byte(pemCertificate))
+	cert, err := x509.ParseCertificate(pemBlock.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var tcs tls.ConnectionState
+	req.TLS = &tcs
+
+	if err := http.Verify(req); err == nil {
+		t.Errorf("Found a valid OU without any being available")
+	}
+
+	// Set a fake OU
+	cert.Subject.OrganizationalUnit = []string{"testing"}
+
+	// Pretend our request had a certificate
+	req.TLS.PeerCertificates = []*x509.Certificate{cert}
+	req.TLS.VerifiedChains = [][]*x509.Certificate{req.TLS.PeerCertificates}
+
+	// Look for fake OU
+	config.Config.SSLValidOUs = []string{"testing"}
+
+	if err := http.Verify(req); err != nil {
+		t.Errorf("Failed to verify certificate OU")
+	}
+}
+
+func TestAppendKeyPair(t *testing.T) {
+	c, err := http.NewTLSConfig("", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemCertFile := writeFakeFile(pemCertificate)
+	defer syscall.Unlink(pemCertFile)
+	pemPKFile := writeFakeFile(pemPrivateKey)
+	defer syscall.Unlink(pemPKFile)
+
+	if err := http.AppendKeyPair(c, pemCertFile, pemPKFile); err != nil {
+		t.Errorf("Failed to append certificate and key to tls config")
+	}
+}
+
+func writeFakeFile(content string) string {
+	f, err := ioutil.TempFile("", "ssl_test")
+	if err != nil {
+		return ""
+	}
+	ioutil.WriteFile(f.Name(), []byte(content), 0644)
+	return f.Name()
+}
+
+// Blatentely stolen from x509's unit tests
+const pemCertificate = `-----BEGIN CERTIFICATE-----
+MIIB5DCCAZCgAwIBAgIBATALBgkqhkiG9w0BAQUwLTEQMA4GA1UEChMHQWNtZSBDbzEZMBcGA1UE
+AxMQdGVzdC5leGFtcGxlLmNvbTAeFw03MDAxMDEwMDE2NDBaFw03MDAxMDIwMzQ2NDBaMC0xEDAO
+BgNVBAoTB0FjbWUgQ28xGTAXBgNVBAMTEHRlc3QuZXhhbXBsZS5jb20wWjALBgkqhkiG9w0BAQED
+SwAwSAJBALKZD0nEffqM1ACuak0bijtqE2QrI/KLADv7l3kK3ppMyCuLKoF0fd7Ai2KW5ToIwzFo
+fvJcS/STa6HA5gQenRUCAwEAAaOBnjCBmzAOBgNVHQ8BAf8EBAMCAAQwDwYDVR0TAQH/BAUwAwEB
+/zANBgNVHQ4EBgQEAQIDBDAPBgNVHSMECDAGgAQBAgMEMBsGA1UdEQQUMBKCEHRlc3QuZXhhbXBs
+ZS5jb20wDwYDVR0gBAgwBjAEBgIqAzAqBgNVHR4EIzAhoB8wDoIMLmV4YW1wbGUuY29tMA2CC2V4
+YW1wbGUuY29tMAsGCSqGSIb3DQEBBQNBAHKZKoS1wEQOGhgklx4+/yFYQlnqwKXvar/ZecQvJwui
+0seMQnwBhwdBkHfVIU2Fu5VUMRyxlf0ZNaDXcpU581k=
+-----END CERTIFICATE-----`
+
+const pemPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIBOgIBAAJBALKZD0nEffqM1ACuak0bijtqE2QrI/KLADv7l3kK3ppMyCuLKoF0
+fd7Ai2KW5ToIwzFofvJcS/STa6HA5gQenRUCAwEAAQJBAIq9amn00aS0h/CrjXqu
+/ThglAXJmZhOMPVn4eiu7/ROixi9sex436MaVeMqSNf7Ex9a8fRNfWss7Sqd9eWu
+RTUCIQDasvGASLqmjeffBNLTXV2A5g4t+kLVCpsEIZAycV5GswIhANEPLmax0ME/
+EO+ZJ79TJKN5yiGBRsv5yvx5UiHxajEXAiAhAol5N4EUyq6I9w1rYdhPMGpLfk7A
+IU2snfRJ6Nq2CQIgFrPsWRCkV+gOYcajD17rEqmuLrdIRexpg8N1DOSXoJ8CIGlS
+tAboUGBxTDq3ZroNism3DaMIbKPyYrAqhKov1h5V
+-----END RSA PRIVATE KEY-----
+`


### PR DESCRIPTION
The PR adds SSL and Mutual TLS support to the web and API interface.  Part of this change modifies some config variables that are in use by the agent.  This was done to clarify SSL config for the server versus SSL for the agent.

If necessary the code can be reworked to look at the new config directives first and try to fall back to the old ones if the new ones are empty.  This could be accompanied by a deprecation method.  I didn't do this immediately because it makes for a lot of ugly code and you had mentioned orchestrator agent wasn't widely used.

Additionally new config values for the agent have been added in preparation of adding Mutual TLS.  They are not currently wired up.  I thought the distinction would be useful given the name cutover, but if it might be confusing to have values that do nothing I can remove them until the other code is ready.

Please let me know what I can change/add/remove to make this a pleasing pull request.  Thanks!