### PR TITLE
Remove per-request message when not checking OUs

### DIFF
--- a/go/http/ssl.go
+++ b/go/http/ssl.go
@@ -77,12 +77,10 @@ func Verify(r *nethttp.Request) error {
 func VerifyOUs() martini.Handler {
 	return func(res nethttp.ResponseWriter, req *nethttp.Request, c martini.Context) {
 		if config.Config.UseMutualTLS {
-			log.Info("Verifying client OU")
+			log.Debug("Verifying client OU")
 			if err := Verify(req); err != nil {
 				nethttp.Error(res, err.Error(), nethttp.StatusUnauthorized)
 			}
-		} else {
-			log.Debug("Mutual TLS disabled, skipping OU check")
 		}
 	}
 }


### PR DESCRIPTION
Small fix to remove logging spam when OUs are not checked.  I have a branch I'm working on for agent ssl that removes verify being added as middleware if mutualTLS isn't enabled, so this message has already been removed there.