### PR TITLE
Adding mutual TLS to the agent API

### DIFF
--- a/go/app/http.go
+++ b/go/app/http.go
@@ -62,7 +62,7 @@ func Http(discovery bool) {
 	standardHttp(discovery)
 }
 
-// standardHttp starts serving standard HTTP (api/web) requests, to be used by normal clients
+// standardHttp starts serving HTTP or HTTPS (api/web) requests, to be used by normal clients
 func standardHttp(discovery bool) {
 	m := martini.Classic()
 
@@ -105,7 +105,9 @@ func standardHttp(discovery bool) {
 		HTMLContentType: "text/html",
 	}))
 	m.Use(martini.Static("resources/public"))
-	m.Use(http.VerifyOUs())
+	if config.Config.UseMutualTLS {
+		m.Use(http.VerifyOUs(config.Config.SSLValidOUs))
+	}
 
 	inst.SetMaintenanceOwner(logic.ThisHostname)
 
@@ -141,13 +143,16 @@ func standardHttp(discovery bool) {
 	log.Info("Web server started")
 }
 
-// agentsHttp startes serving agents API requests
+// agentsHttp startes serving agents HTTP or HTTPS API requests
 func agentsHttp() {
 	m := martini.Classic()
 	m.Use(gzip.All())
 	m.Use(render.Renderer())
+	if config.Config.AgentsUseMutualTLS {
+		m.Use(http.VerifyOUs(config.Config.AgentSSLValidOUs))
+	}
 
-	log.Info("Starting agents HTTP")
+	log.Info("Starting agents listener")
 
 	go logic.ContinuousAgentsPoll()
 
@@ -155,12 +160,22 @@ func agentsHttp() {
 
 	// Serve
 	if config.Config.AgentsUseSSL {
-		log.Info("Serving via SSL")
-		err := nethttp.ListenAndServeTLS(config.Config.AgentsServerPort, config.Config.AgentSSLCertFile, config.Config.AgentSSLPrivateKeyFile, m)
+		log.Info("Starting agent HTTPS listener")
+		tlsConfig, err := http.NewTLSConfig(config.Config.AgentSSLCAFile, config.Config.AgentsUseMutualTLS)
 		if err != nil {
 			log.Fatale(err)
 		}
+		if err = http.AppendKeyPair(tlsConfig, config.Config.AgentSSLCertFile, config.Config.AgentSSLPrivateKeyFile); err != nil {
+			log.Fatale(err)
+		}
+		if err = http.ListenAndServeTLS(config.Config.AgentsServerPort, m, tlsConfig); err != nil {
+			log.Fatale(err)
+		}
 	} else {
-		nethttp.ListenAndServe(config.Config.AgentsServerPort, m)
+		log.Info("Starting agent HTTP listener")
+		if err := nethttp.ListenAndServe(config.Config.AgentsServerPort, m); err != nil {
+			log.Fatale(err)
+		}
 	}
+	log.Info("Agent server started")
 }

--- a/go/http/ssl_test.go
+++ b/go/http/ssl_test.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/outbrain/orchestrator/go/config"
 	"github.com/outbrain/orchestrator/go/http"
 )
 
@@ -57,12 +56,14 @@ func TestNewTLSConfig(t *testing.T) {
 }
 
 func TestVerify(t *testing.T) {
+	var validOUs []string
+
 	req, err := nethttp.NewRequest("GET", "http://example.com/foo", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := http.Verify(req); err == nil {
+	if err := http.Verify(req, validOUs); err == nil {
 		t.Errorf("Did not fail on lack of TLS config")
 	}
 
@@ -75,7 +76,7 @@ func TestVerify(t *testing.T) {
 	var tcs tls.ConnectionState
 	req.TLS = &tcs
 
-	if err := http.Verify(req); err == nil {
+	if err := http.Verify(req, validOUs); err == nil {
 		t.Errorf("Found a valid OU without any being available")
 	}
 
@@ -87,9 +88,9 @@ func TestVerify(t *testing.T) {
 	req.TLS.VerifiedChains = [][]*x509.Certificate{req.TLS.PeerCertificates}
 
 	// Look for fake OU
-	config.Config.SSLValidOUs = []string{"testing"}
+	validOUs = []string{"testing"}
 
-	if err := http.Verify(req); err != nil {
+	if err := http.Verify(req, validOUs); err != nil {
 		t.Errorf("Failed to verify certificate OU")
 	}
 }


### PR DESCRIPTION
This mimics the mutual TLS settings for the Web/API interface on the Agent API.  There were a few modifications made to the existing code:
* Allowing OU list to be passed to verify since the agent and server list can be different
* Moving mutual TLS check out since those are also different.
