### PR TITLE
Adding TLS authentication for MySQL

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -35,13 +35,23 @@ type Configuration struct {
 	MySQLTopologyUser                          string
 	MySQLTopologyPassword                      string // my.cnf style configuration file from where to pick credentials. Expecting `user`, `password` under `[client]` section
 	MySQLTopologyCredentialsConfigFile         string
-	MySQLTopologyMaxPoolConnections            int // Max concurrent connections on any topology instance
+	MySQLTopologySSLPrivateKeyFile             string // Private key file used to authenticate with a Topology mysql instance with TLS
+	MySQLTopologySSLCertFile                   string // Certificate PEM file used to authenticate with a Topology mysql instance with TLS
+	MySQLTopologySSLCAFile                     string // Certificate Authority PEM file used to authenticate with a Topology mysql instance with TLS
+	MySQLTopologySSLSkipVerify                 bool   // If true, do not strictly validate mutual TLS certs for Topology mysql instances
+	MySQLTopologyUseMutualTLS                  bool   // Turn on TLS authentication with the Topology MySQL instances
+	MySQLTopologyMaxPoolConnections            int    // Max concurrent connections on any topology instance
 	MySQLOrchestratorHost                      string
 	MySQLOrchestratorPort                      uint
 	MySQLOrchestratorDatabase                  string
 	MySQLOrchestratorUser                      string
 	MySQLOrchestratorPassword                  string
 	MySQLOrchestratorCredentialsConfigFile     string // my.cnf style configuration file from where to pick credentials. Expecting `user`, `password` under `[client]` section
+	MySQLOrchestratorSSLPrivateKeyFile         string // Private key file used to authenticate with the Orchestrator mysql instance with TLS
+	MySQLOrchestratorSSLCertFile               string // Certificate PEM file used to authenticate with the Orchestrator mysql instance with TLS
+	MySQLOrchestratorSSLCAFile                 string // Certificate Authority PEM file used to authenticate with the Orchestrator mysql instance with TLS
+	MySQLOrchestratorSSLSkipVerify             bool   // If true, do not strictly validate mutual TLS certs for the Orchestrator mysql instances
+	MySQLOrchestratorUseMutualTLS              bool   // Turn on TLS authentication with the Orchestrator MySQL instance
 	MySQLConnectTimeoutSeconds                 int    // Number of seconds before connection is aborted (driver-side)
 	DefaultInstancePort                        int    // In case port was not specified on command line
 	SkipOrchestratorDatabaseUpdate             bool   // When false, orchestrator will attempt to create & update all tables in backend database; when true, this is skipped. It makes sense to skip on command-line invocations and to enable for http or occasional invocations, or just after upgrades
@@ -134,6 +144,8 @@ func NewConfiguration() *Configuration {
 		AgentsServerPort:                           ":3001",
 		MySQLOrchestratorPort:                      3306,
 		MySQLTopologyMaxPoolConnections:            3,
+		MySQLTopologyUseMutualTLS:                  false,
+		MySQLOrchestratorUseMutualTLS:              false,
 		MySQLConnectTimeoutSeconds:                 5,
 		DefaultInstancePort:                        3306,
 		SkipOrchestratorDatabaseUpdate:             false,

--- a/go/ssl/ssl.go
+++ b/go/ssl/ssl.go
@@ -1,4 +1,4 @@
-package http
+package ssl
 
 import (
 	"crypto/tls"
@@ -27,9 +27,8 @@ func HasString(elem string, arr []string) bool {
 func NewTLSConfig(caFile string, mutualTLS bool) (*tls.Config, error) {
 	var c tls.Config
 
-	// No sslv3 or tls 1.0
+	// TLS 1.0 at a minimum (for mysql)
 	c.MinVersion = tls.VersionTLS10
-	c.MaxVersion = tls.VersionTLS12
 	c.PreferServerCipherSuites = true
 
 	if mutualTLS {

--- a/go/ssl/ssl_test.go
+++ b/go/ssl/ssl_test.go
@@ -1,4 +1,4 @@
-package http_test
+package ssl_test
 
 import (
 	"crypto/tls"
@@ -10,18 +10,18 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/outbrain/orchestrator/go/http"
+	"github.com/outbrain/orchestrator/go/ssl"
 )
 
 func TestHasString(t *testing.T) {
 	elem := "foo"
 	a1 := []string{"bar", "foo", "baz"}
 	a2 := []string{"bar", "fuu", "baz"}
-	good := http.HasString(elem, a1)
+	good := ssl.HasString(elem, a1)
 	if !good {
 		t.Errorf("Didn't find %s in array %s", elem, strings.Join(a1, ", "))
 	}
-	bad := http.HasString(elem, a2)
+	bad := ssl.HasString(elem, a2)
 	if bad {
 		t.Errorf("Unexpectedly found %s in array %s", elem, strings.Join(a2, ", "))
 	}
@@ -32,7 +32,7 @@ func TestNewTLSConfig(t *testing.T) {
 	fakeCA := writeFakeFile(pemCertificate)
 	defer syscall.Unlink(fakeCA)
 
-	conf, err := http.NewTLSConfig(fakeCA, true)
+	conf, err := ssl.NewTLSConfig(fakeCA, true)
 	if err != nil {
 		t.Errorf("Could not create new TLS config: %s", err)
 	}
@@ -43,7 +43,7 @@ func TestNewTLSConfig(t *testing.T) {
 		t.Errorf("ClientCA empty even though cert provided")
 	}
 
-	conf, err = http.NewTLSConfig("", false)
+	conf, err = ssl.NewTLSConfig("", false)
 	if err != nil {
 		t.Errorf("Could not create new TLS config: %s", err)
 	}
@@ -63,7 +63,7 @@ func TestVerify(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := http.Verify(req, validOUs); err == nil {
+	if err := ssl.Verify(req, validOUs); err == nil {
 		t.Errorf("Did not fail on lack of TLS config")
 	}
 
@@ -76,7 +76,7 @@ func TestVerify(t *testing.T) {
 	var tcs tls.ConnectionState
 	req.TLS = &tcs
 
-	if err := http.Verify(req, validOUs); err == nil {
+	if err := ssl.Verify(req, validOUs); err == nil {
 		t.Errorf("Found a valid OU without any being available")
 	}
 
@@ -90,13 +90,13 @@ func TestVerify(t *testing.T) {
 	// Look for fake OU
 	validOUs = []string{"testing"}
 
-	if err := http.Verify(req, validOUs); err != nil {
+	if err := ssl.Verify(req, validOUs); err != nil {
 		t.Errorf("Failed to verify certificate OU")
 	}
 }
 
 func TestAppendKeyPair(t *testing.T) {
-	c, err := http.NewTLSConfig("", false)
+	c, err := ssl.NewTLSConfig("", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestAppendKeyPair(t *testing.T) {
 	pemPKFile := writeFakeFile(pemPrivateKey)
 	defer syscall.Unlink(pemPKFile)
 
-	if err := http.AppendKeyPair(c, pemCertFile, pemPKFile); err != nil {
+	if err := ssl.AppendKeyPair(c, pemCertFile, pemPKFile); err != nil {
 		t.Errorf("Failed to append certificate and key to tls config")
 	}
 }


### PR DESCRIPTION
This change  adds the ability to authenticate with mutual TLS certificates with a mysql database for both orchestrator and topology.
* Current the same TLS config is used for all hosts in the topology.  There's no ability to mix some password topology hosts with some tls topology hosts.  This is a little more coarse grain than I like and I'll look to improving it in the future, though I'm not 100% sure the right way to build a router for that.
* The TLS config is only set up once, this should work long term, I believe, but there could be situations where it needs to be re-initialized.  We'll address that if it becomes an issue.
* Added config variables to support TLS
* Moving the ssl functions out to their own package to resolve bad/circular import cycle when go/db imported go/http
* Adding verification skipping to all TLS points. This was inadvertantly removed prior from the Agent API