### PR TITLE
Adding configurable status endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ vagrant/db3-post-install.sh
 vagrant/db4-post-install.sh
 vagrant/vagrant-ssh-key
 vagrant/vagrant-ssh-key.pub
+Godeps/_workspace

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -108,6 +108,9 @@ type Configuration struct {
 	SSLCertFile                                string            // Name of SSL certification file, applies only when UseSSL = true
 	SSLCAFile                                  string            // Name of the Certificate Authority file, applies only when UseSSL = true
 	SSLValidOUs                                []string          // Valid organizational units when using mutual TLS
+	StatusEndpoint                             string            // Override the status endpoint.  Defaults to '/api/status'
+	StatusSimpleHealth                         bool              // If true, calling the status endpoint will use the simplified health check
+	StatusOUVerify                             bool              // If true, try to verify OUs when Mutual TLS is on.  Defaults to false
 	HttpTimeoutSeconds                         int               // Number of idle seconds before HTTP GET request times out (when accessing orchestrator-agent)
 	AgentPollMinutes                           uint              // Minutes between agent polling
 	UnseenAgentForgetHours                     uint              // Number of hours after which an unseen agent is forgotten
@@ -144,6 +147,9 @@ func NewConfiguration() *Configuration {
 		Debug:                                      false,
 		ListenAddress:                              ":3000",
 		AgentsServerPort:                           ":3001",
+		StatusEndpoint:                             "/api/status",
+		StatusSimpleHealth:                         true,
+		StatusOUVerify:                             false,
 		MySQLOrchestratorPort:                      3306,
 		MySQLTopologyMaxPoolConnections:            3,
 		MySQLTopologyUseMutualTLS:                  false,

--- a/go/logic/health_dao.go
+++ b/go/logic/health_dao.go
@@ -18,6 +18,7 @@ package logic
 
 import (
 	"fmt"
+
 	"github.com/outbrain/golib/log"
 	"github.com/outbrain/golib/sqlutils"
 	"github.com/outbrain/orchestrator/go/db"
@@ -104,4 +105,23 @@ Cleanup:
 		log.Errore(err)
 	}
 	return res, err
+}
+
+// Just check to make sure we can connect to the database
+func SimpleHealthTest() (*HealthStatus, error) {
+	health := HealthStatus{Healthy: false, Hostname: ThisHostname, Token: ProcessToken.Hash}
+
+	db, err := db.OpenOrchestrator()
+	if err != nil {
+		health.Error = err
+		return &health, log.Errore(err)
+	}
+
+	if err = db.Ping(); err != nil {
+		health.Error = err
+		return &health, log.Errore(err)
+	} else {
+		health.Healthy = true
+		return &health, nil
+	}
 }

--- a/go/ssl/ssl.go
+++ b/go/ssl/ssl.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-martini/martini"
 	"github.com/outbrain/golib/log"
+	"github.com/outbrain/orchestrator/go/config"
 )
 
 // Determine if a string element is in a string array
@@ -53,8 +54,11 @@ func NewTLSConfig(caFile string, mutualTLS bool) (*tls.Config, error) {
 // Verify that the OU of the presented client certificate matches the list
 // of Valid OUs
 func Verify(r *nethttp.Request, validOUs []string) error {
+	if strings.Contains(r.URL.String(), config.Config.StatusEndpoint) && !config.Config.StatusOUVerify {
+		return nil
+	}
 	if r.TLS == nil {
-		return errors.New("no TLS")
+		return errors.New("No TLS")
 	}
 	for _, chain := range r.TLS.VerifiedChains {
 		s := chain[0].Subject.OrganizationalUnit


### PR DESCRIPTION
This lets us match our internal health checks, I'm sure this will be
useful to others as well.
Not modifying Health() since it returns 200 of failure and there might
be people depending on the behavior.
Adding SimpleHealthCheck() that just validates DB connectivity, not
necessarily writes.
Adding config endpoints for status stuff