### PR TITLE
Adding Agent Auto Discovery

### DIFF
--- a/go/agent/agent.go
+++ b/go/agent/agent.go
@@ -16,6 +16,8 @@
 
 package agent
 
+import "github.com/outbrain/orchestrator/go/inst"
+
 // LogicalVolume describes an LVM volume
 type LogicalVolume struct {
 	Name            string
@@ -72,4 +74,9 @@ type SeedOperationState struct {
 	StateTimestamp string
 	Action         string
 	ErrorMessage   string
+}
+
+// Build an instance key for a given agent
+func (this *Agent) GetInstance() *inst.InstanceKey {
+	return &inst.InstanceKey{Hostname: this.Hostname, Port: int(this.MySQLPort)}
 }

--- a/go/agent/agent_dao.go
+++ b/go/agent/agent_dao.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -123,12 +122,7 @@ func DiscoverAgentInstance(hostname string, port int) error {
 		return err
 	}
 
-	instanceKey, err := inst.NewInstanceKeyFromStrings(hostname, strconv.FormatInt(agent.MySQLPort, 10))
-	if err != nil {
-		log.Errorf("Failed to build instance key for %s:%d", hostname, agent.MySQLPort)
-		return err
-	}
-
+	instanceKey := agent.GetInstance()
 	instance, err := inst.ReadTopologyInstance(instanceKey)
 	if err != nil {
 		log.Errorf("Failed to read topology for %v", instanceKey)

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -113,6 +113,7 @@ type Configuration struct {
 	StatusOUVerify                             bool              // If true, try to verify OUs when Mutual TLS is on.  Defaults to false
 	HttpTimeoutSeconds                         int               // Number of idle seconds before HTTP GET request times out (when accessing orchestrator-agent)
 	AgentPollMinutes                           uint              // Minutes between agent polling
+	AgentAutoDiscover                          bool              // If true, instances should automatically discover when an agent is submitted
 	UnseenAgentForgetHours                     uint              // Number of hours after which an unseen agent is forgotten
 	StaleSeedFailMinutes                       uint              // Number of minutes after which a stale (no progress) seed is considered failed.
 	SeedAcceptableBytesDiff                    int64             // Difference in bytes between seed source & target data size that is still considered as successful copy
@@ -212,6 +213,7 @@ func NewConfiguration() *Configuration {
 		SSLCAFile:                                  "",
 		HttpTimeoutSeconds:                         60,
 		AgentPollMinutes:                           60,
+		AgentAutoDiscover:                          false,
 		UnseenAgentForgetHours:                     6,
 		StaleSeedFailMinutes:                       60,
 		SeedAcceptableBytesDiff:                    8192,


### PR DESCRIPTION
Allow the agent submission process to also cause the mysql instance to
be discovered.

This will be disabled by default, but we thought it would be really handy if an agent coming online caused a topology instance to be discovered.  This feels relatively safe and simple, but I'm definitely open to reasons why we wouldn't want to do this.

This just seemed like the most expedient way to get us automatic discovery, since we're going to deploy the agent anyhow.