### PR TITLE
Keep GTID from being enabled

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -125,6 +125,7 @@ type Configuration struct {
 	PseudoGTIDPattern                          string            // Pattern to look for in binary logs that makes for a unique entry (pseudo GTID). When empty, Pseudo-GTID based refactoring is disabled.
 	PseudoGTIDMonotonicHint                    string            // subtring in Pseudo-GTID entry which indicates Pseudo-GTID entries are expected to be monotonically increasing
 	DetectPseudoGTIDQuery                      string            // Optional query which is used to authoritatively decide whether pseudo gtid is enabled on instance
+	AllowGTIDMode                              bool              // If true, GTID mode can be enabled by powerusers via the Web UI or API.  Otherwise GTID mode can not be enabled.
 	BinlogEventsChunkSize                      int               // Chunk size (X) for SHOW BINLOG|RELAYLOG EVENTS LIMIT ?,X statements. Smaller means less locking and mroe work to be done
 	BufferBinlogEvents                         bool              // Should we used buffered read on SHOW BINLOG|RELAYLOG EVENTS -- releases the database lock sooner (recommended)
 	SkipBinlogEventsContaining                 []string          // When scanning/comparing binlogs for Pseudo-GTID, skip entries containing given texts. These are NOT regular expressions (would consume too much CPU while scanning binlogs), just substrings to find.
@@ -233,6 +234,7 @@ func NewConfiguration() *Configuration {
 		PseudoGTIDPattern:                          "",
 		PseudoGTIDMonotonicHint:                    "",
 		DetectPseudoGTIDQuery:                      "",
+		AllowGTIDMode:                              true,
 		BinlogEventsChunkSize:                      10000,
 		BufferBinlogEvents:                         true,
 		SkipBinlogEventsContaining:                 []string{},

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -442,7 +442,7 @@ func (this *HttpAPI) ReattachSlave(params martini.Params, r render.Render, req *
 
 // EnableGTID attempts to enable GTID on a slave
 func (this *HttpAPI) EnableGTID(params martini.Params, r render.Render, req *http.Request, user auth.User) {
-	if !isAuthorizedForAction(req, user) {
+	if !isAuthorizedForAction(req, user) || !config.Config.AllowGTIDMode {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
 		return
 	}


### PR DESCRIPTION
For environments that don't ever want to turn on GTID, this keeps
someone from accidentally pushing the button.  I'm still looking at the
javascript to figure out a good way to just remove the button in a
configurable way, but I also want this to keep someone from using the
CLI to do it.