### PR TITLE
Use new location for gcfg

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"os"
 
-	"code.google.com/p/gcfg"
+	"gopkg.in/gcfg.v1"
 
 	"github.com/outbrain/golib/log"
 )


### PR DESCRIPTION
The location for gcfg has changed. 
I didn't run any tests, so be careful.