### PR TITLE
Show the actual RejectHostnameResolvePattern for clarity

### DIFF
--- a/go/inst/resolve.go
+++ b/go/inst/resolve.go
@@ -98,7 +98,7 @@ func ResolveHostname(hostname string) (string, error) {
 	if config.Config.RejectHostnameResolvePattern != "" {
 		// Reject, don't even cache
 		if matched, _ := regexp.MatchString(config.Config.RejectHostnameResolvePattern, resolvedHostname); matched {
-			log.Warningf("ResolveHostname: %+v resolved to %+v but rejected due to RejectHostnameResolvePattern", hostname, resolvedHostname)
+			log.Warningf("ResolveHostname: %+v resolved to %+v but rejected due to RejectHostnameResolvePattern '%+v'", hostname, resolvedHostname, config.Config.RejectHostnameResolvePattern)
 			return hostname, nil
 		}
 	}


### PR DESCRIPTION
The current error message does not show actual pattern which was used which may confuse.
My patch includes this to make things clearer.