### PR TITLE
If moving under a binlog server first validate it is reachable

### DIFF
--- a/go/inst/binlog.go
+++ b/go/inst/binlog.go
@@ -87,6 +87,15 @@ func (this *BinlogCoordinates) SmallerThan(other *BinlogCoordinates) bool {
 	return false
 }
 
+// SmallerThanOrEquals returns true if this coordinate is the same or equal to the other one.
+// We do NOT compare the type so we can not use this.Equals()
+func (this *BinlogCoordinates) SmallerThanOrEquals(other *BinlogCoordinates) bool {
+	if this.SmallerThan(other) {
+		return true
+	}
+	return this.LogFile == other.LogFile && this.LogPos == other.LogPos // No Type comparison
+}
+
 // FileSmallerThan returns true if this coordinate's file is strictly smaller than the other's.
 func (this *BinlogCoordinates) FileSmallerThan(other *BinlogCoordinates) bool {
 	return this.LogFile < other.LogFile

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -667,7 +667,7 @@ func MoveSlavesGTID(masterKey *InstanceKey, belowKey *InstanceKey, pattern strin
 // Two use cases:
 // - masterKey is nil: use case is corrupted relay logs on slave
 // - masterKey is not nil: using Binlog servers (coordinates remain the same)
-func Repoint(instanceKey *InstanceKey, masterKey *InstanceKey, gitdHint OperationGTIDHint) (*Instance, error) {
+func Repoint(instanceKey *InstanceKey, masterKey *InstanceKey, gtidHint OperationGTIDHint) (*Instance, error) {
 	instance, err := ReadTopologyInstance(instanceKey)
 	if err != nil {
 		return instance, err
@@ -679,7 +679,7 @@ func Repoint(instanceKey *InstanceKey, masterKey *InstanceKey, gitdHint Operatio
 	if masterKey == nil {
 		masterKey = &instance.MasterKey
 	}
-	// With repoint we *prefer* the master to be alive, but we don't structly require it.
+	// With repoint we *prefer* the master to be alive, but we don't strictly require it.
 	// The use case for the master being alive is with hostname-resolve or hostname-unresolve: asking the slave
 	// to reconnect to its same master while changing the MASTER_HOST in CHANGE MASTER TO due to DNS changes etc.
 	master, err := ReadTopologyInstance(masterKey)
@@ -692,6 +692,17 @@ func Repoint(instanceKey *InstanceKey, masterKey *InstanceKey, gitdHint Operatio
 	}
 	if canReplicate, err := instance.CanReplicateFrom(master); !canReplicate {
 		return instance, err
+	}
+
+	// if a binlog server check it is sufficiently up to date
+	if master.IsBinlogServer() {
+		// If this fails I should wait a short period of
+		// time and try again a few times prior to giving up as
+		// the binlog server may be a bit behind but should catch
+		// up quickly.
+		if !instance.ExecBinlogCoordinates.SmallerThanOrEquals(&master.ExecBinlogCoordinates) {
+			return instance, fmt.Errorf("binlog server %+v is not sufficiently up to date to move %+v below it", *masterKey, *instanceKey)
+		}
 	}
 
 	log.Infof("Will repoint %+v to master %+v", *instanceKey, *masterKey)
@@ -711,7 +722,7 @@ func Repoint(instanceKey *InstanceKey, masterKey *InstanceKey, gitdHint Operatio
 	// See above, we are relaxed about the master being accessible/inaccessible.
 	// If accessible, we wish to do hostname-unresolve. If inaccessible, we can skip the test and not fail the
 	// ChangeMasterTo operation. This is why we pass "!masterIsAccessible" below.
-	instance, err = ChangeMasterTo(instanceKey, masterKey, &instance.ExecBinlogCoordinates, !masterIsAccessible, gitdHint)
+	instance, err = ChangeMasterTo(instanceKey, masterKey, &instance.ExecBinlogCoordinates, !masterIsAccessible, gtidHint)
 	if err != nil {
 		goto Cleanup
 	}
@@ -2133,6 +2144,10 @@ func relocateBelowInternal(instance, other *Instance) (*Instance, error) {
 		otherMaster, found, err := ReadInstance(&other.MasterKey)
 		if err != nil || !found {
 			return instance, err
+		}
+		// ensure the other binlog server is up prior to attempting to moving under it.
+		if !other.IsLastCheckValid {
+			return instance, log.Errorf("Server %+v is not reachable. Can not move %+v under it.", other.Key, instance.Key)
 		}
 		if _, err := relocateBelowInternal(instance, otherMaster); err != nil {
 			return instance, err


### PR DESCRIPTION
* When moving under a binlog server check first that it is reachable, and do not continue if it is not.
* fix a typo
* Ensure that the binlog server's position is at least as up to date as the slave we are moving.