### PR TITLE
build.sh checks for GOROOT which needs not be set.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,13 +34,13 @@ function precheck() {
     echo "rpmbuild not in PATH, rpm will not be built"
   fi
 
-  if [[ -z "$GOROOT" || -z "$GOPATH" ]]; then
-    echo "GOROOT or GOPATH not set"
+  if [[ -z "$GOPATH" ]]; then
+    echo "GOPATH not set"
     ok=1
   fi
 
-  if [[ ! -x "$GOROOT/bin/go" ]]; then
-    echo "go binary not found at $GOROOT/bin/go"
+  if [[ ! -x "$( which go )" ]]; then
+    echo "go binary not found in PATH"
     ok=1
   fi
 


### PR DESCRIPTION
See: http://dave.cheney.net/2013/06/14/you-dont-need-to-set-goroot-really

Basically I have GOPATH set and nothing set for GOROOT and build.sh
complains.  It should not do that.  So check go is in the PATH.