### PR TITLE
relocate treatment of comasters bugfix

### DIFF
--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -2360,11 +2360,14 @@ func relocateBelowInternal(instance, other *Instance) (*Instance, error) {
 	}
 	// No Pseudo-GTID; cehck simple binlog file/pos operations:
 	if InstancesAreSiblings(instance, other) {
-		return MoveBelow(&instance.Key, &other.Key)
+		// If comastering, only move below if it's read-only
+		if !other.IsCoMaster || other.ReadOnly {
+			return MoveBelow(&instance.Key, &other.Key)
+		}
 	}
 	// See if we need to MoveUp
 	if instanceMaster.MasterKey.Equals(&other.Key) {
-		// Moving to grandparent
+		// Moving to grandparent--handles co-mastering writable case
 		return MoveUp(&instance.Key)
 	}
 	if instanceMaster.IsBinlogServer() {


### PR DESCRIPTION
Fix bug where MoveBelow was used when MoveUp was appropriate with regards to the direction of writes.

Only uses MoveBelow if not a comaster, or is read-only.  Falls back to MoveUp otherwise.

Without this change, events will be skipped when relocating a replica from passive comaster to active comaster.