### PR TITLE
coordinates history:

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -733,7 +733,7 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			if instance == nil {
 				log.Fatalf("Instance not found: %+v", *instanceKey)
 			}
-			coordinates, err := inst.SearchEntryInInstanceBinlogs(instance, pattern, false)
+			coordinates, err := inst.SearchEntryInInstanceBinlogs(instance, pattern, false, nil)
 			if err != nil {
 				log.Fatale(err)
 			}

--- a/go/db/db.go
+++ b/go/db/db.go
@@ -136,7 +136,7 @@ var generateSQLBase = []string{
           PRIMARY KEY (audit_id),
           KEY audit_timestamp_idx (audit_timestamp),
           KEY host_port_idx (hostname, port, audit_timestamp)
-        ) ENGINE=InnoDB DEFAULT CHARSET=latin1 
+        ) ENGINE=InnoDB DEFAULT CHARSET=latin1
 	`,
 	`
 		CREATE TABLE IF NOT EXISTS host_agent (
@@ -443,86 +443,101 @@ var generateSQLBase = []string{
 		  KEY first_seen_active_idx(first_seen_active)
 		) ENGINE=InnoDB DEFAULT CHARSET=ascii
 	`,
+	`
+		CREATE TABLE IF NOT EXISTS database_instance_coordinates_history (
+          history_id bigint unsigned not null auto_increment,
+		  hostname varchar(128) NOT NULL,
+		  port smallint(5) unsigned NOT NULL,
+		  recorded_timestamp timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		  binary_log_file varchar(128) NOT NULL,
+		  binary_log_pos bigint(20) unsigned NOT NULL,
+		  relay_log_file varchar(128) NOT NULL,
+		  relay_log_pos bigint(20) unsigned NOT NULL,
+		  PRIMARY KEY (history_id),
+		  KEY hostname_port_recorded_timestmp_idx (hostname, port, recorded_timestamp),
+		  KEY recorded_timestmp_idx (recorded_timestamp)
+		) ENGINE=InnoDB DEFAULT CHARSET=ascii
+	`,
 }
 
 var generateSQLPatches = []string{
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN read_only TINYINT UNSIGNED NOT NULL AFTER version
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN last_sql_error TEXT NOT NULL AFTER exec_master_log_pos
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN last_io_error TEXT NOT NULL AFTER last_sql_error
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN last_attempted_check TIMESTAMP AFTER last_checked
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN oracle_gtid TINYINT UNSIGNED NOT NULL AFTER slave_io_running
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN mariadb_gtid TINYINT UNSIGNED NOT NULL AFTER oracle_gtid
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN relay_log_file varchar(128) CHARACTER SET ascii NOT NULL AFTER exec_master_log_pos
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN relay_log_pos bigint unsigned NOT NULL AFTER relay_log_file
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD INDEX master_host_port_idx (master_host, master_port)
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN pseudo_gtid TINYINT UNSIGNED NOT NULL AFTER mariadb_gtid
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN replication_depth TINYINT UNSIGNED NOT NULL AFTER cluster_name
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN has_replication_filters TINYINT UNSIGNED NOT NULL AFTER slave_io_running
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN data_center varchar(32) CHARACTER SET ascii NOT NULL AFTER cluster_name
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN physical_environment varchar(32) CHARACTER SET ascii NOT NULL AFTER data_center
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance_maintenance
 			ADD KEY active_timestamp_idx (maintenance_active, begin_timestamp)
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN uptime INT UNSIGNED NOT NULL AFTER last_seen
 	`,
@@ -532,22 +547,22 @@ var generateSQLPatches = []string{
 			ADD UNIQUE KEY alias_uidx (alias)
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN is_co_master TINYINT UNSIGNED NOT NULL AFTER replication_depth
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance_maintenance
 			ADD KEY active_end_timestamp_idx (maintenance_active, end_timestamp)
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN sql_delay INT UNSIGNED NOT NULL AFTER slave_lag_seconds
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			topology_recovery
 			ADD COLUMN analysis              varchar(128) CHARACTER SET ascii NOT NULL,
 			ADD COLUMN cluster_name          varchar(128) CHARACTER SET ascii NOT NULL,
@@ -569,7 +584,7 @@ var generateSQLPatches = []string{
 			ADD KEY end_recovery_idx (end_recovery)
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN binlog_server TINYINT UNSIGNED NOT NULL AFTER version
 	`,
@@ -579,22 +594,22 @@ var generateSQLPatches = []string{
 			ADD KEY last_registered_idx (last_registered)
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN supports_oracle_gtid TINYINT UNSIGNED NOT NULL AFTER oracle_gtid
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN executed_gtid_set text CHARACTER SET ascii NOT NULL AFTER oracle_gtid
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN server_uuid varchar(64) CHARACTER SET ascii NOT NULL AFTER server_id
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN suggested_cluster_alias varchar(128) CHARACTER SET ascii NOT NULL AFTER cluster_name
 	`,
@@ -604,19 +619,19 @@ var generateSQLPatches = []string{
 			ADD KEY last_registered_idx (last_registered)
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			topology_recovery
 			ADD COLUMN is_successful TINYINT UNSIGNED NOT NULL DEFAULT 0 AFTER processcing_node_token
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			topology_recovery
 			ADD COLUMN acknowledged TINYINT UNSIGNED NOT NULL DEFAULT 0,
 			ADD COLUMN acknowledged_by varchar(128) CHARACTER SET utf8 NOT NULL,
 			ADD COLUMN acknowledge_comment text CHARACTER SET utf8 NOT NULL
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			topology_recovery
 			ADD COLUMN participating_instances text CHARACTER SET ascii NOT NULL after slave_hosts,
 			ADD COLUMN lost_slaves text CHARACTER SET ascii NOT NULL after participating_instances,
@@ -631,13 +646,13 @@ var generateSQLPatches = []string{
 			ADD COLUMN priority TINYINT SIGNED NOT NULL DEFAULT 1 comment 'positive promote, nagative unpromotes'
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			topology_recovery
 			ADD COLUMN acknowledged_at TIMESTAMP NULL after acknowledged,
 			ADD KEY acknowledged_idx (acknowledged, acknowledged_at)
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			blocked_topology_recovery
 			ADD KEY last_blocked_idx (last_blocked_timestamp)
 	`,
@@ -676,24 +691,24 @@ var generateSQLPatches = []string{
 			MODIFY last_suggested timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN last_attempted_check TIMESTAMP NOT NULL DEFAULT '1971-01-01 00:00:00' AFTER last_checked
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			MODIFY last_attempted_check TIMESTAMP NOT NULL DEFAULT '1971-01-01 00:00:00'
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance_analysis_changelog
 			ADD KEY instance_timestamp_idx (hostname, port, analysis_timestamp)
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			topology_recovery
-			ADD COLUMN last_detection_id bigint unsigned NOT NULL, 
+			ADD COLUMN last_detection_id bigint unsigned NOT NULL,
 			ADD KEY last_detection_idx (last_detection_id)
 	`,
 	`
@@ -709,7 +724,7 @@ var generateSQLPatches = []string{
 			ADD COLUMN version varchar(128) CHARACTER SET ascii NOT NULL
 	`,
 	`
-		ALTER TABLE 
+		ALTER TABLE
 			database_instance
 			ADD COLUMN gtid_purged text CHARACTER SET ascii NOT NULL AFTER executed_gtid_set
 	`,
@@ -783,10 +798,10 @@ func readInternalDeployments() (baseDeployments []string, patchDeployments []str
 		return baseDeployments, patchDeployments, nil
 	}
 	query := fmt.Sprintf(`
-		select 
-			deployment_type, 
-			sql_statement  
-		from 
+		select
+			deployment_type,
+			sql_statement
+		from
 			_orchestrator_db_deployment
 		order by
 			deployment_id

--- a/go/inst/instance_binlog_dao.go
+++ b/go/inst/instance_binlog_dao.go
@@ -132,7 +132,6 @@ func getLastPseudoGTIDEntryInInstance(instance *Instance, minBinlogCoordinates *
 			minBinlogCoordinates = nil
 			log.Debugf("Heuristic binlog search failed; continuing exhaustive search")
 			// And we do NOT iterate the log file: we scan same log faile again, with no heuristic
-			//return nil, "", log.Errorf("past minBinlogCoordinates (%+v); skipping iteration over rest of binary logs", *minBinlogCoordinates)
 		} else {
 			currentBinlog, err = currentBinlog.PreviousFileCoordinates()
 			if err != nil {

--- a/go/inst/instance_binlog_dao.go
+++ b/go/inst/instance_binlog_dao.go
@@ -18,15 +18,16 @@ package inst
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/outbrain/golib/log"
 	"github.com/outbrain/golib/math"
 	"github.com/outbrain/golib/sqlutils"
 	"github.com/outbrain/orchestrator/go/config"
 	"github.com/outbrain/orchestrator/go/db"
 	"github.com/pmylund/go-cache"
-	"regexp"
-	"strings"
-	"time"
 )
 
 const maxEmptyBinlogFiles int = 10
@@ -43,7 +44,7 @@ func getInstanceBinlogEntryKey(instance *Instance, entry string) string {
 // maxCoordinates is the position beyond which we should not read. This is relevant when reading relay logs; in particular,
 // the last relay log. We must be careful not to scan for Pseudo-GTID entries past the position executed by the SQL thread.
 // maxCoordinates == nil means no limit.
-func getLastPseudoGTIDEntryInBinlog(instanceKey *InstanceKey, binlog string, binlogType BinlogType, maxCoordinates *BinlogCoordinates) (*BinlogCoordinates, string, error) {
+func getLastPseudoGTIDEntryInBinlog(instanceKey *InstanceKey, binlog string, binlogType BinlogType, minCoordinates *BinlogCoordinates, maxCoordinates *BinlogCoordinates) (*BinlogCoordinates, string, error) {
 	if binlog == "" {
 		return nil, "", log.Errorf("getLastPseudoGTIDEntryInBinlog: empty binlog file name for %+v. maxCoordinates = %+v", *instanceKey, maxCoordinates)
 	}
@@ -55,6 +56,12 @@ func getLastPseudoGTIDEntryInBinlog(instanceKey *InstanceKey, binlog string, bin
 
 	moreRowsExpected := true
 	var nextPos int64 = 0
+	var relyLogMinPos int64 = 0
+	if minCoordinates != nil && minCoordinates.LogFile == binlog {
+		log.Debugf("getLastPseudoGTIDEntryInBinlog: starting with %+v", *minCoordinates)
+		nextPos = minCoordinates.LogPos
+		relyLogMinPos = minCoordinates.LogPos
+	}
 	step := 0
 
 	entryText := ""
@@ -63,7 +70,7 @@ func getLastPseudoGTIDEntryInBinlog(instanceKey *InstanceKey, binlog string, bin
 		if binlogCoordinates.Type == BinaryLog {
 			query = fmt.Sprintf("show binlog events in '%s' FROM %d LIMIT %d", binlog, nextPos, config.Config.BinlogEventsChunkSize)
 		} else {
-			query = fmt.Sprintf("show relaylog events in '%s' LIMIT %d,%d", binlog, (step * config.Config.BinlogEventsChunkSize), config.Config.BinlogEventsChunkSize)
+			query = fmt.Sprintf("show relaylog events in '%s' FROM %d LIMIT %d,%d", binlog, relyLogMinPos, (step * config.Config.BinlogEventsChunkSize), config.Config.BinlogEventsChunkSize)
 		}
 
 		moreRowsExpected = false
@@ -101,14 +108,14 @@ func getLastPseudoGTIDEntryInBinlog(instanceKey *InstanceKey, binlog string, bin
 	return &binlogCoordinates, entryText, err
 }
 
-func getLastPseudoGTIDEntryInInstance(instance *Instance, maxBinlogCoordinates *BinlogCoordinates, exhaustiveSearch bool) (*BinlogCoordinates, string, error) {
+func getLastPseudoGTIDEntryInInstance(instance *Instance, minBinlogCoordinates *BinlogCoordinates, maxBinlogCoordinates *BinlogCoordinates, exhaustiveSearch bool) (*BinlogCoordinates, string, error) {
 	// Look for last GTID in instance:
 	currentBinlog := instance.SelfBinlogCoordinates
 
 	var err error = nil
 	for err == nil {
 		log.Debugf("Searching for latest pseudo gtid entry in binlog %+v of %+v", currentBinlog.LogFile, instance.Key)
-		resultCoordinates, entryInfo, err := getLastPseudoGTIDEntryInBinlog(&instance.Key, currentBinlog.LogFile, BinaryLog, maxBinlogCoordinates)
+		resultCoordinates, entryInfo, err := getLastPseudoGTIDEntryInBinlog(&instance.Key, currentBinlog.LogFile, BinaryLog, minBinlogCoordinates, maxBinlogCoordinates)
 		if err != nil {
 			return nil, "", err
 		}
@@ -119,12 +126,24 @@ func getLastPseudoGTIDEntryInInstance(instance *Instance, maxBinlogCoordinates *
 		if !exhaustiveSearch {
 			break
 		}
-		currentBinlog, err = currentBinlog.PreviousFileCoordinates()
+		if minBinlogCoordinates != nil && minBinlogCoordinates.LogFile == currentBinlog.LogFile {
+			// We tried and failed with the minBinlogCoordinates hint. We no longer require it,
+			// and continue with exhaustive search.
+			minBinlogCoordinates = nil
+			log.Debugf("Heuristic binlog search failed; continuing exhaustive search")
+			// And we do NOT iterate the log file: we scan same log faile again, with no heuristic
+			//return nil, "", log.Errorf("past minBinlogCoordinates (%+v); skipping iteration over rest of binary logs", *minBinlogCoordinates)
+		} else {
+			currentBinlog, err = currentBinlog.PreviousFileCoordinates()
+			if err != nil {
+				return nil, "", err
+			}
+		}
 	}
 	return nil, "", log.Errorf("Cannot find pseudo GTID entry in binlogs of %+v", instance.Key)
 }
 
-func getLastPseudoGTIDEntryInRelayLogs(instance *Instance, recordedInstanceRelayLogCoordinates BinlogCoordinates, exhaustiveSearch bool) (*BinlogCoordinates, string, error) {
+func getLastPseudoGTIDEntryInRelayLogs(instance *Instance, minBinlogCoordinates *BinlogCoordinates, recordedInstanceRelayLogCoordinates BinlogCoordinates, exhaustiveSearch bool) (*BinlogCoordinates, string, error) {
 	// Look for last GTID in relay logs:
 	// Since MySQL does not provide with a SHOW RELAY LOGS command, we heuristically srtart from current
 	// relay log (indiciated by Relay_log_file) and walk backwards.
@@ -133,7 +152,7 @@ func getLastPseudoGTIDEntryInRelayLogs(instance *Instance, recordedInstanceRelay
 	var err error = nil
 	for err == nil {
 		log.Debugf("Searching for latest pseudo gtid entry in relaylog %+v of %+v, up to pos %+v", currentRelayLog.LogFile, instance.Key, recordedInstanceRelayLogCoordinates)
-		if resultCoordinates, entryInfo, err := getLastPseudoGTIDEntryInBinlog(&instance.Key, currentRelayLog.LogFile, RelayLog, &recordedInstanceRelayLogCoordinates); err != nil {
+		if resultCoordinates, entryInfo, err := getLastPseudoGTIDEntryInBinlog(&instance.Key, currentRelayLog.LogFile, RelayLog, minBinlogCoordinates, &recordedInstanceRelayLogCoordinates); err != nil {
 			return nil, "", err
 		} else if resultCoordinates != nil {
 			log.Debugf("Found pseudo gtid entry in %+v, %+v", instance.Key, resultCoordinates)
@@ -142,13 +161,21 @@ func getLastPseudoGTIDEntryInRelayLogs(instance *Instance, recordedInstanceRelay
 		if !exhaustiveSearch {
 			break
 		}
-		currentRelayLog, err = currentRelayLog.PreviousFileCoordinates()
+		if minBinlogCoordinates != nil && minBinlogCoordinates.LogFile == currentRelayLog.LogFile {
+			// We tried and failed with the minBinlogCoordinates hint. We no longer require it,
+			// and continue with exhaustive search.
+			minBinlogCoordinates = nil
+			log.Debugf("Heuristic relaylog search failed; continuing exhaustive search")
+			// And we do NOT iterate the log file: we scan same log faile again, with no heuristic
+		} else {
+			currentRelayLog, err = currentRelayLog.PreviousFileCoordinates()
+		}
 	}
 	return nil, "", log.Errorf("Cannot find pseudo GTID entry in relay logs of %+v", instance.Key)
 }
 
 // SearchEntryInBinlog Given a binlog entry text (query), search it in the given binary log of a given instance
-func SearchEntryInBinlog(instanceKey *InstanceKey, binlog string, entryText string, monotonicPseudoGTIDEntries bool) (BinlogCoordinates, bool, error) {
+func SearchEntryInBinlog(instanceKey *InstanceKey, binlog string, entryText string, monotonicPseudoGTIDEntries bool, minBinlogCoordinates *BinlogCoordinates) (BinlogCoordinates, bool, error) {
 	binlogCoordinates := BinlogCoordinates{LogFile: binlog, LogPos: 0, Type: BinaryLog}
 	if binlog == "" {
 		return binlogCoordinates, false, log.Errorf("SearchEntryInBinlog: empty binlog file name for %+v", *instanceKey)
@@ -163,6 +190,10 @@ func SearchEntryInBinlog(instanceKey *InstanceKey, binlog string, entryText stri
 	skipRestOfBinlog := false
 	alreadyMatchedAscendingPseudoGTID := false
 	var nextPos int64 = 0
+	if minBinlogCoordinates != nil && minBinlogCoordinates.LogFile == binlog {
+		log.Debugf("SearchEntryInBinlog: starting with %+v", *minBinlogCoordinates)
+		nextPos = minBinlogCoordinates.LogPos
+	}
 
 	//	commandToken := math.TernaryString(binlogCoordinates.Type == BinaryLog, "binlog", "relaylog")
 	for moreRowsExpected {
@@ -225,7 +256,7 @@ func SearchEntryInBinlog(instanceKey *InstanceKey, binlog string, entryText stri
 }
 
 // SearchEntryInInstanceBinlogs will search for a specific text entry within the binary logs of a given instance.
-func SearchEntryInInstanceBinlogs(instance *Instance, entryText string, monotonicPseudoGTIDEntries bool) (*BinlogCoordinates, error) {
+func SearchEntryInInstanceBinlogs(instance *Instance, entryText string, monotonicPseudoGTIDEntries bool, minBinlogCoordinates *BinlogCoordinates) (*BinlogCoordinates, error) {
 	cacheKey := getInstanceBinlogEntryKey(instance, entryText)
 	coords, found := instanceBinlogEntryCache.Get(cacheKey)
 	if found {
@@ -259,7 +290,7 @@ func SearchEntryInInstanceBinlogs(instance *Instance, entryText string, monotoni
 		}
 		var resultCoordinates BinlogCoordinates
 		var found bool = false
-		resultCoordinates, found, err = SearchEntryInBinlog(&instance.Key, currentBinlog.LogFile, entryText, monotonicPseudoGTIDEntries)
+		resultCoordinates, found, err = SearchEntryInBinlog(&instance.Key, currentBinlog.LogFile, entryText, monotonicPseudoGTIDEntries, minBinlogCoordinates)
 		if err != nil {
 			break
 		}
@@ -269,11 +300,16 @@ func SearchEntryInInstanceBinlogs(instance *Instance, entryText string, monotoni
 			return &resultCoordinates, nil
 		}
 		// Got here? Unfound. Keep looking
-		currentBinlog, err = currentBinlog.PreviousFileCoordinates()
-		if err != nil {
-			break
+		if minBinlogCoordinates != nil && minBinlogCoordinates.LogFile == currentBinlog.LogFile {
+			log.Debugf("Heuristic master binary logs search failed; continuing exhaustive search")
+			minBinlogCoordinates = nil
+		} else {
+			currentBinlog, err = currentBinlog.PreviousFileCoordinates()
+			if err != nil {
+				break
+			}
+			log.Debugf("- Will move next to binlog %+v", currentBinlog.LogFile)
 		}
-		log.Debugf("- Will move next to binlog %+v", currentBinlog.LogFile)
 	}
 
 	return nil, log.Errorf("Cannot match pseudo GTID entry in binlogs of %+v; err: %+v", instance.Key, err)

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -18,13 +18,14 @@ package inst
 
 import (
 	"fmt"
-	"github.com/outbrain/golib/log"
-	"github.com/outbrain/golib/math"
-	"github.com/outbrain/orchestrator/go/config"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/outbrain/golib/log"
+	"github.com/outbrain/golib/math"
+	"github.com/outbrain/orchestrator/go/config"
 )
 
 // getASCIITopologyEntry will get an ascii topology tree rooted at given instance. Ir recursively
@@ -792,7 +793,7 @@ func RepointTo(slaves [](*Instance), belowKey *InstanceKey) ([](*Instance), erro
 	return res, nil, errs
 }
 
-// RepointSlaves repoints slaves of a given instance (possibly filtered) onto another master.
+// RepointSlavesTo repoints slaves of a given instance (possibly filtered) onto another master.
 // Binlog Server is the major use case
 func RepointSlavesTo(instanceKey *InstanceKey, pattern string, belowKey *InstanceKey) ([](*Instance), error, []error) {
 	res := [](*Instance){}
@@ -1111,7 +1112,7 @@ Cleanup:
 		return instance, log.Errore(err)
 	}
 	// and we're done (pending deferred functions)
-	AuditOperation("repoint", instanceKey, fmt.Sprintf("slave %+v reattached to master $+v", *instanceKey, *reattachedMasterKey))
+	AuditOperation("repoint", instanceKey, fmt.Sprintf("slave %+v reattached to master %+v", *instanceKey, *reattachedMasterKey))
 
 	return instance, err
 }
@@ -1242,8 +1243,8 @@ Cleanup:
 func FindLastPseudoGTIDEntry(instance *Instance, recordedInstanceRelayLogCoordinates BinlogCoordinates, maxBinlogCoordinates *BinlogCoordinates, exhaustiveSearch bool, expectedBinlogFormat *string) (*BinlogCoordinates, string, error) {
 	var instancePseudoGtidText string
 	var instancePseudoGtidCoordinates *BinlogCoordinates
-	var err error
 
+	minBinlogCoordinates, minRelaylogCoordinates, err := GetHeuristiclyRecentCoordinatesForInstance(&instance.Key)
 	if instance.LogBinEnabled && instance.LogSlaveUpdatesEnabled && (expectedBinlogFormat == nil || instance.Binlog_format == *expectedBinlogFormat) {
 		// Well no need to search this instance's binary logs if it doesn't have any...
 		// With regard log-slave-updates, some edge cases are possible, like having this instance's log-slave-updates
@@ -1253,18 +1254,19 @@ func FindLastPseudoGTIDEntry(instance *Instance, recordedInstanceRelayLogCoordin
 		// for relay logs.
 		// Also, if master has STATEMENT binlog format, and the slave has ROW binlog format, then comparing binlog entries would urely fail if based on the slave's binary logs.
 		// Instead, we revert to the relay logs.
-		instancePseudoGtidCoordinates, instancePseudoGtidText, err = getLastPseudoGTIDEntryInInstance(instance, maxBinlogCoordinates, exhaustiveSearch)
+		instancePseudoGtidCoordinates, instancePseudoGtidText, err = getLastPseudoGTIDEntryInInstance(instance, minBinlogCoordinates, maxBinlogCoordinates, exhaustiveSearch)
 	}
 	if err != nil || instancePseudoGtidCoordinates == nil {
 		// Unable to find pseudo GTID in binary logs.
 		// Then MAYBE we are lucky enough (chances are we are, if this slave did not crash) that we can
 		// extract the Pseudo GTID entry from the last (current) relay log file.
-		instancePseudoGtidCoordinates, instancePseudoGtidText, err = getLastPseudoGTIDEntryInRelayLogs(instance, recordedInstanceRelayLogCoordinates, exhaustiveSearch)
+		instancePseudoGtidCoordinates, instancePseudoGtidText, err = getLastPseudoGTIDEntryInRelayLogs(instance, minRelaylogCoordinates, recordedInstanceRelayLogCoordinates, exhaustiveSearch)
 	}
 	return instancePseudoGtidCoordinates, instancePseudoGtidText, err
 }
 
-// CorrelateBinlogCoordinates
+// CorrelateBinlogCoordinates find out, if possible, the binlog coordinates of given otherInstance that correlate
+// with given coordinates of given instance.
 func CorrelateBinlogCoordinates(instance *Instance, binlogCoordinates *BinlogCoordinates, otherInstance *Instance) (*BinlogCoordinates, int, error) {
 
 	// We record the relay log coordinates just after the instance stopped since the coordinates can change upon
@@ -1277,7 +1279,8 @@ func CorrelateBinlogCoordinates(instance *Instance, binlogCoordinates *BinlogCoo
 		return nil, 0, err
 	}
 	entriesMonotonic := (config.Config.PseudoGTIDMonotonicHint != "") && strings.Contains(instancePseudoGtidText, config.Config.PseudoGTIDMonotonicHint)
-	otherInstancePseudoGtidCoordinates, err := SearchEntryInInstanceBinlogs(otherInstance, instancePseudoGtidText, entriesMonotonic)
+	minBinlogCoordinates, _, err := GetHeuristiclyRecentCoordinatesForInstance(&otherInstance.Key)
+	otherInstancePseudoGtidCoordinates, err := SearchEntryInInstanceBinlogs(otherInstance, instancePseudoGtidText, entriesMonotonic, minBinlogCoordinates)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -2033,8 +2036,7 @@ func GetCandidateSlaveOfBinlogServerTopology(masterKey *InstanceKey) (candidateS
 	return candidateSlave, err
 }
 
-// RegroupSlaves will choose a candidate slave of a given instance, and enslave its siblings using
-// either simple CHANGE MASTER TO, where possible, or pseudo-gtid
+// RegroupSlavesPseudoGTID will choose a candidate slave of a given instance, and enslave its siblings using pseudo-gtid
 func RegroupSlavesPseudoGTID(masterKey *InstanceKey, returnSlaveEvenOnFailureToRegroup bool, onCandidateSlaveChosen func(*Instance), postponedFunctionsContainer *PostponedFunctionsContainer) ([](*Instance), [](*Instance), [](*Instance), *Instance, error) {
 	candidateSlave, aheadSlaves, equalSlaves, laterSlaves, err := GetCandidateSlave(masterKey, true)
 	if err != nil {
@@ -2113,8 +2115,9 @@ func getMostUpToDateActiveBinlogServer(masterKey *InstanceKey) (mostAdvancedBinl
 	return mostAdvancedBinlogServer, binlogServerSlaves, err
 }
 
-// RegroupSlavesIncludingSubSlavesOfBinlogServers works in a mixed standard/binlog-server topology. This kind of topology shouldn't really exist,
-// but life is hard. To transition binlog servers into your topology you live sometimes with this hybrid solution.
+// RegroupSlavesPseudoGTIDIncludingSubSlavesOfBinlogServers uses Pseugo-GTID to regroup slaves
+// of given instance. The function also drill in to slaves of binlog servers that are replicating from given instance,
+// and other recursive binlog servers, as long as they're in the same binlog-server-family.
 func RegroupSlavesPseudoGTIDIncludingSubSlavesOfBinlogServers(masterKey *InstanceKey, returnSlaveEvenOnFailureToRegroup bool, onCandidateSlaveChosen func(*Instance), postponedFunctionsContainer *PostponedFunctionsContainer) ([](*Instance), [](*Instance), [](*Instance), *Instance, error) {
 	// First, handle binlog server issues:
 	func() error {

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -17,6 +17,11 @@
 package logic
 
 import (
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
 	"github.com/outbrain/golib/log"
 	"github.com/outbrain/golib/math"
 	"github.com/outbrain/orchestrator/go/agent"
@@ -26,10 +31,6 @@ import (
 	"github.com/outbrain/orchestrator/go/process"
 	"github.com/pmylund/go-cache"
 	"github.com/rcrowley/go-metrics"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
 )
 
 const (
@@ -193,6 +194,7 @@ func ContinuousDiscovery() {
 			// Various periodic internal maintenance tasks
 			go func() {
 				if isElectedNode {
+					go inst.RecordInstanceCoordinatesHistory()
 					go inst.ForgetLongUnseenInstances()
 					go inst.ForgetUnseenInstancesDifferentlyResolved()
 					go inst.ForgetExpiredHostnameResolves()


### PR DESCRIPTION
- added database_instance_coordinates_history table
- logic periodically records binlog coordinates
  - also periodically purges this table
- search for latest pseudo-gtid entry or for given pseudo-gtid entry attempts, heuristically, to begin the search at recently recorded coordinates (and fails back to exhaustive search if unfound)