### PR TITLE
Clean environment prior to starting and wait properly for orchestrato…

### DIFF
--- a/etc/init.d/orchestrator.bash
+++ b/etc/init.d/orchestrator.bash
@@ -23,7 +23,8 @@ case "$1" in
   start)
     printf "%-50s" "Starting $NAME..."
     cd $DAEMON_PATH
-    PID=$(./$DAEMON $DAEMONOPTS >> /var/log/${NAME}.log 2>&1 & echo $!)
+    # Ensure orchestrator's environment is clean
+    PID=$(env -i ./$DAEMON $DAEMONOPTS >> /var/log/${NAME}.log 2>&1 & echo $!)
     #echo "Saving PID" $PID " to " $PIDFILE
     if [ -z $PID ]; then
       printf "%s\n" "Fail"
@@ -57,8 +58,16 @@ case "$1" in
     cd $DAEMON_PATH
     if [ -f $PIDFILE ]; then
       kill -TERM $PID
-      printf "%s\n" "Ok"
       rm -f $PIDFILE
+      # Wait for orchestrator to stop otherwise restart may fail.
+      # (The newly restarted process may be unable to bind to the
+      # currently bound socket.)
+      while ps -p $PID >/dev/null 2>&1; do
+        printf "."
+        sleep 1
+      done
+      printf "\n"
+      printf "Ok\n"
     else
       printf "%s\n" "pidfile not found"
       exit 1


### PR DESCRIPTION
…r to stop

The current init script does not clean up the environment so this
may make orchestrator behave different depending on the environment
of the caller.

When stopping orchestrator sometimes takes time to shutdown, and
if you do not wait starting it will fail as it is likely to be still
bound to the listen port. This change ensures we wait for orchestrator
to terminate properly.