### PR TITLE
Optionally configure explicit pool size to orchestrator db backend

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -44,6 +44,7 @@ type Configuration struct {
 	MySQLTopologyMaxPoolConnections            int    // Max concurrent connections on any topology instance
 	DatabaselessMode__experimental             bool   // !!!EXPERIMENTAL!!! Orchestrator will execute without speaking to a backend database; super-standalone mode
 	MySQLOrchestratorHost                      string
+	MySQLOrchestratorMaxPoolConnections        int    // The maximum size of the connection pool to the Orchestrator backend.
 	MySQLOrchestratorPort                      uint
 	MySQLOrchestratorDatabase                  string
 	MySQLOrchestratorUser                      string
@@ -165,6 +166,7 @@ func NewConfiguration() *Configuration {
 		StatusEndpoint:                             "/api/status",
 		StatusSimpleHealth:                         true,
 		StatusOUVerify:                             false,
+		MySQLOrchestratorMaxPoolConnections:        0,    // default no limit to pool size but this should really be set.
 		MySQLOrchestratorPort:                      3306,
 		MySQLTopologyMaxPoolConnections:            3,
 		MySQLTopologyUseMutualTLS:                  false,

--- a/go/db/db.go
+++ b/go/db/db.go
@@ -772,6 +772,10 @@ func OpenOrchestrator() (*sql.DB, error) {
 		if !config.Config.SkipOrchestratorDatabaseUpdate {
 			initOrchestratorDB(db)
 		}
+		if config.Config.MySQLOrchestratorMaxPoolConnections > 0 {
+			log.Debugf("Orchestrator pool SetMaxOpenConns: %d", config.Config.MySQLOrchestratorMaxPoolConnections)
+			db.SetMaxOpenConns(config.Config.MySQLOrchestratorMaxPoolConnections)
+		}
 		db.SetMaxIdleConns(10)
 	}
 	return db, err


### PR DESCRIPTION
This is done to prevent overloading the backend if a large number
of instances need to be checked.