### PR TITLE
Merge downstream gh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-orchestrator [[Manual]](https://github.com/github/orchestrator/wiki/Orchestrator-Manual)
+orchestrator [[Manual]](https://github.com/outbrain/orchestrator/wiki/Orchestrator-Manual)
 ============
 
 _Orchestrator_ is a MySQL replication topology management and visualization tool, allowing for:
@@ -38,7 +38,7 @@ _Orchestrator_ supports:
 - Web API (HTTP GET access)
 - Web interface, a _slick_ one.
 
-![Orcehstrator screenshot](https://github.com/github/orchestrator/wiki/images/orchestrator-introduction-screenshot.png)
+![Orcehstrator screenshot](https://github.com/outbrain/orchestrator/wiki/images/orchestrator-introduction-screenshot.png)
 
 #### More
 
@@ -52,6 +52,6 @@ _Orchestrator_ supports:
 - When working with [orchestrator-agent](https://github.com/outbrain/orchestrator-agent), seed new/corrupt instances
 - More...
 
-Read the [Orchestrator Manual](https://github.com/github/orchestrator/wiki/Orchestrator-Manual) for comprehensive documentation.
+Read the [Orchestrator Manual](https://github.com/outbrain/orchestrator/wiki/Orchestrator-Manual) for comprehensive documentation.
 
 Authored by [Shlomi Noach](https://github.com/shlomi-noach) at [GitHub](http://github.com). Previously at [Booking.com](http://booking.com) and [Outbrain](http://outbrain.com)

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@
 #
 set -e
 
-RELEASE_VERSION="1.4.569"
+RELEASE_VERSION="1.4.570"
 TOPDIR=/tmp/orchestrator-release
 export RELEASE_VERSION TOPDIR
 export GO15VENDOREXPERIMENT=1

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@
 #
 set -e
 
-RELEASE_VERSION="1.4.570"
+RELEASE_VERSION="1.4.571"
 TOPDIR=/tmp/orchestrator-release
 export RELEASE_VERSION TOPDIR
 export GO15VENDOREXPERIMENT=1

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -105,6 +105,7 @@ type Configuration struct {
 	DetectClusterDomainQuery                     string            // Optional query (executed on topology instance) that returns the VIP/CNAME/Alias/whatever domain name for the master of this cluster. Query will only be executed on cluster master (though until the topology's master is resovled it may execute on other/all slaves). If provided, must return one row, one column
 	DataCenterPattern                            string            // Regexp pattern with one group, extracting the datacenter name from the hostname
 	PhysicalEnvironmentPattern                   string            // Regexp pattern with one group, extracting physical environment info from hostname (e.g. combination of datacenter & prod/dev env)
+	SupportFuzzyPoolHostnames                    bool              // Should "submit-pool-instances" command be able to pass list of fuzzy instances (fuzzy means non-fqdn, but unique enough to recognize). Defaults 'true', implies more queries on backend db
 	PromotionIgnoreHostnameFilters               []string          // Orchestrator will not promote slaves with hostname matching pattern (via -c recovery; for example, avoid promoting dev-dedicated machines)
 	ServeAgentsHttp                              bool              // Spawn another HTTP interface dedicated for orcehstrator-agent
 	AgentsUseSSL                                 bool              // When "true" orchestrator will listen on agents port with SSL as well as connect to agents via SSL
@@ -232,6 +233,7 @@ func newConfiguration() *Configuration {
 		DetectClusterDomainQuery:                     "",
 		DataCenterPattern:                            "",
 		PhysicalEnvironmentPattern:                   "",
+		SupportFuzzyPoolHostnames:                    true,
 		PromotionIgnoreHostnameFilters:               []string{},
 		ServeAgentsHttp:                              false,
 		AgentsUseSSL:                                 false,

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -105,6 +105,8 @@ type Configuration struct {
 	DetectClusterDomainQuery                     string            // Optional query (executed on topology instance) that returns the VIP/CNAME/Alias/whatever domain name for the master of this cluster. Query will only be executed on cluster master (though until the topology's master is resovled it may execute on other/all slaves). If provided, must return one row, one column
 	DataCenterPattern                            string            // Regexp pattern with one group, extracting the datacenter name from the hostname
 	PhysicalEnvironmentPattern                   string            // Regexp pattern with one group, extracting physical environment info from hostname (e.g. combination of datacenter & prod/dev env)
+	DetectDataCenterQuery                        string            // Optional query (executed on topology instance) that returns the data center of an instance. If provided, must return one row, one column. Overrides DataCenterPattern and useful for installments where DC cannot be inferred by hostname
+	DetectPhysicalEnvironmentQuery               string            // Optional query (executed on topology instance) that returns the physical environment of an instance. If provided, must return one row, one column. Overrides PhysicalEnvironmentPattern and useful for installments where env cannot be inferred by hostname
 	SupportFuzzyPoolHostnames                    bool              // Should "submit-pool-instances" command be able to pass list of fuzzy instances (fuzzy means non-fqdn, but unique enough to recognize). Defaults 'true', implies more queries on backend db
 	PromotionIgnoreHostnameFilters               []string          // Orchestrator will not promote slaves with hostname matching pattern (via -c recovery; for example, avoid promoting dev-dedicated machines)
 	ServeAgentsHttp                              bool              // Spawn another HTTP interface dedicated for orcehstrator-agent
@@ -233,6 +235,8 @@ func newConfiguration() *Configuration {
 		DetectClusterDomainQuery:                     "",
 		DataCenterPattern:                            "",
 		PhysicalEnvironmentPattern:                   "",
+		DetectDataCenterQuery:                        "",
+		DetectPhysicalEnvironmentQuery:               "",
 		SupportFuzzyPoolHostnames:                    true,
 		PromotionIgnoreHostnameFilters:               []string{},
 		ServeAgentsHttp:                              false,

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -1026,14 +1026,16 @@ func GetClusterOSCSlaves(clusterName string) ([](*Instance), error) {
 }
 
 // GetInstancesMaxLag returns the maximum lag in a set of instances
-func GetInstancesMaxLag(instances [](*Instance)) int64 {
-	var maxLag int64
+func GetInstancesMaxLag(instances [](*Instance)) (maxLag int64, err error) {
+	if len(instances) == 0 {
+		return 0, log.Errorf("No instances found in GetInstancesMaxLag")
+	}
 	for _, clusterInstance := range instances {
 		if clusterInstance.SlaveLagSeconds.Valid && clusterInstance.SlaveLagSeconds.Int64 > maxLag {
 			maxLag = clusterInstance.SlaveLagSeconds.Int64
 		}
 	}
-	return maxLag
+	return maxLag, nil
 }
 
 // GetClusterHeuristicLag returns a heuristic lag for a cluster, based on its OSC slaves
@@ -1042,7 +1044,7 @@ func GetClusterHeuristicLag(clusterName string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return GetInstancesMaxLag(instances), nil
+	return GetInstancesMaxLag(instances)
 }
 
 // GetHeuristicClusterPoolInstances returns instances of a cluster which are also pooled. If `pool` argument
@@ -1088,7 +1090,7 @@ func GetHeuristicClusterPoolInstancesLag(clusterName string, pool string) (int64
 	if err != nil {
 		return 0, err
 	}
-	return GetInstancesMaxLag(instances), nil
+	return GetInstancesMaxLag(instances)
 }
 
 // updateInstanceClusterName

--- a/go/inst/pool.go
+++ b/go/inst/pool.go
@@ -17,8 +17,11 @@
 package inst
 
 import (
-	"github.com/outbrain/golib/log"
 	"strings"
+
+	"github.com/outbrain/orchestrator/go/config"
+
+	"github.com/outbrain/golib/log"
 )
 
 // PoolInstancesMap lists instance keys per pool name
@@ -40,7 +43,9 @@ func ApplyPoolInstances(pool string, instancesList string) error {
 		for _, instanceString := range instancesStrings {
 
 			instanceKey, err := ParseInstanceKeyLoose(instanceString)
-			instanceKey = ReadFuzzyInstanceKeyIfPossible(instanceKey)
+			if config.Config.SupportFuzzyPoolHostnames {
+				instanceKey = ReadFuzzyInstanceKeyIfPossible(instanceKey)
+			}
 			log.Debugf("%+v", instanceKey)
 			if err != nil {
 				return log.Errore(err)

--- a/resources/templates/about.tmpl
+++ b/resources/templates/about.tmpl
@@ -46,7 +46,7 @@
                 <i>Orchestrator</i> is released as open source under the
                 <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 license</a>
                 and is available at:
-                <a href="https://github.com/github/orchestrator">https://github.com/github/orchestrator</a>
+                <a href="https://github.com/outbrain/orchestrator">https://github.com/outbrain/orchestrator</a>
             </p>
             <p>
                 Developed by Shlomi Noach.

--- a/resources/templates/faq.tmpl
+++ b/resources/templates/faq.tmpl
@@ -99,7 +99,7 @@
                 <i>Orchestrator</i> is released as open source under the
                 <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 license</a>
                 and is available at:
-                <a href="https://github.com/github/orchestrator">https://github.com/github/orchestrator</a>
+                <a href="https://github.com/outbrain/orchestrator">https://github.com/outbrain/orchestrator</a>
             </p>
             <p>
                 <strong>Who develops orchestrator and why?</strong>

--- a/resources/templates/layout.tmpl
+++ b/resources/templates/layout.tmpl
@@ -42,7 +42,7 @@
 						class="icon-bar"></span> <span class="icon-bar"></span> <span
 						class="icon-bar"></span>
 				</button>
-				<a class="navbar-brand orchestrator-brand" href="https://github.com/github/orchestrator">orchestrator</a>
+				<a class="navbar-brand orchestrator-brand" href="https://github.com/outbrain/orchestrator">orchestrator</a>
 
 			</div>
 			<div class="collapse navbar-collapse">
@@ -55,8 +55,8 @@
                         </a>
                         <ul class="dropdown-menu">
                             <li><a href="/web/about">About</a></li>
-                            <li><a href="https://github.com/github/orchestrator/wiki/Orchestrator-Manual" target="_blank">Manual</a></li>
-                            <li><a href="https://github.com/github/orchestrator/wiki/FAQ" target="_blank">FAQ</a></li>
+                            <li><a href="https://github.com/outbrain/orchestrator/wiki/Orchestrator-Manual" target="_blank">Manual</a></li>
+                            <li><a href="https://github.com/outbrain/orchestrator/wiki/FAQ" target="_blank">FAQ</a></li>
                             <li><a href="/web/keep-calm">Keep calm</a></li>
 		                    <li role="presentation" class="divider"></li>
                             <li><a href="/web/status">Status</a></li>


### PR DESCRIPTION
- added `DetectDataCenterQuery` and `DetectPhysicalEnvironmentQuery` config variables, that override `DataCenterPattern` and `PhysicalEnvironmentPattern`, respectively, if present. These are useful for installments where DC and ENV cannot be deduced by hostname. Almost closes https://github.com/outbrain/orchestrator/issues/150, with `promotion_ignore` to be treated differently.

- REALLY fixed `recentDiscoveryOperationKeys`, which was initialized _before_ configuration was loaded.