### PR TITLE
vagrant ssh config fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 conf/orchestrator.conf.json
+.DS_Store
 .vagrant/
 vagrant/admin-post-install.sh
 vagrant/db-post-install.sh

--- a/vagrant/base-build.sh
+++ b/vagrant/base-build.sh
@@ -57,19 +57,19 @@ cp /orchestrator/vagrant/vagrant-ssh-key.pub /home/vagrant/.ssh/id_rsa.pub
 cat <<EOF > /home/vagrant/.ssh/config
 Host admin
   User vagrant
-  IdentifyFile /home/vagrant/.ssh/id_rsa
+  IdentityFile /home/vagrant/.ssh/id_rsa
 Host db1
   User vagrant
-  IdentifyFile /home/vagrant/.ssh/id_rsa
+  IdentityFile /home/vagrant/.ssh/id_rsa
 Host db2
   User vagrant
-  IdentifyFile /home/vagrant/.ssh/id_rsa
+  IdentityFile /home/vagrant/.ssh/id_rsa
 Host db3
   User vagrant
-  IdentifyFile /home/vagrant/.ssh/id_rsa
+  IdentityFile /home/vagrant/.ssh/id_rsa
 Host db4
   User vagrant
-  IdentifyFile /home/vagrant/.ssh/id_rsa
+  IdentityFile /home/vagrant/.ssh/id_rsa
 EOF
 
 chmod go-rwx /home/vagrant/.ssh/*


### PR DESCRIPTION
Typo in `.ssh/config`: `IdentifyFile` should be `IdentityFile`




woops, it also has a `.gitignore` to ignore `.DS_Store`. sorry :)