### PR TITLE
Ruby 1.8.7 bug with fpm causes build failures

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -102,13 +102,13 @@ function package() {
 
       echo "Creating Distro full packages"
       fpm -v "${RELEASE_VERSION}" --epoch 1 -f -s dir -t rpm -n orchestrator -C $builddir/orchestrator --prefix=/ .
-      fpm -v "${RELEASE_VERSION}" --epoch 1 -f -s dir -t deb -n orchestrator -C $builddir/orchestrator --prefix=/ .
+      fpm -v "${RELEASE_VERSION}" --epoch 1 -f -s dir -t deb -n orchestrator -C $builddir/orchestrator --prefix=/ --deb-no-default-config-files .
 
       cd $TOPDIR
       # rpm packaging -- executable only
       echo "Creating Distro cli packages"
       fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -t rpm -n orchestrator-cli -C $builddir/orchestrator-cli --prefix=/ .
-      fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -t deb -n orchestrator-cli -C $builddir/orchestrator-cli --prefix=/ .
+      fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -t deb -n orchestrator-cli -C $builddir/orchestrator-cli --prefix=/ --deb-no-default-config-files .
       ;;
     'darwin')
       echo "Creating Darwin full Package"


### PR DESCRIPTION
I am using the `vagrant` boxes provided in the repository to build orchestrator.

```
[vagrant@admin orchestrator]$ cat /etc/redhat-release 
CentOS release 6.6 (Final)
```

however, the build fails, and it's related to https://github.com/jordansissel/fpm/issues/923

```
[vagrant@admin orchestrator]$ ./build.sh 
Building via go version go1.5.1 linux/amd64
orchestrator binary created
binary copied to orchestrator-cli
Release version is 1.4.575
Creating Linux Tar package
Creating Distro full packages
Created package {:path=>"orchestrator-1.4.575-1.x86_64.rpm"}
epoch in Version is set {:epoch=>"1", :level=>:warn}
Debian packaging tools generally labels all files in /etc as config files, as mandated by policy, so fpm defaults to this behavior for deb packages. You can disable this default behavior with --deb-no-default-config-files flag {:level=>:warn}
/usr/lib/ruby/1.8/find.rb:39:in `find': no block given (LocalJumpError)
	from /usr/lib/ruby/1.8/find.rb:38:in `catch'
	from /usr/lib/ruby/1.8/find.rb:38:in `find'
	from /usr/lib/ruby/gems/1.8/gems/fpm-1.4.0/lib/fpm/package/deb.rb:671:in `add_path'
	from /usr/lib/ruby/gems/1.8/gems/fpm-1.4.0/lib/fpm/package/deb.rb:692:in `write_conffiles'
	from /usr/lib/ruby/gems/1.8/gems/fpm-1.4.0/lib/fpm/package/deb.rb:590:in `write_control_tarball'
	from /usr/lib/ruby/gems/1.8/gems/fpm-1.4.0/lib/fpm/package/deb.rb:389:in `output'
	from /usr/lib/ruby/gems/1.8/gems/fpm-1.4.0/lib/fpm/command.rb:475:in `execute'
	from /usr/lib/ruby/gems/1.8/gems/clamp-0.6.5/lib/clamp/command.rb:67:in `run'
	from /usr/lib/ruby/gems/1.8/gems/fpm-1.4.0/lib/fpm/command.rb:535:in `run'
	from /usr/lib/ruby/gems/1.8/gems/clamp-0.6.5/lib/clamp/command.rb:132:in `run'
	from /usr/lib/ruby/gems/1.8/gems/fpm-1.4.0/bin/fpm:8
	from /usr/bin/fpm:19:in `load'
	from /usr/bin/fpm:19
[vagrant@admin orchestrator]$ ruby --version
ruby 1.8.7 (2013-06-27 patchlevel 374) [x86_64-linux]
```


I fixed it by adding  `--deb-no-default-config-files` to the `fpm deb` commands.