### PR TITLE
Merge downstream: promotion-rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-orchestrator [[Manual]](https://github.com/github/orchestrator/wiki/Orchestrator-Manual)
+orchestrator [[Manual]](https://github.com/outbrain/orchestrator/wiki/Orchestrator-Manual)
 ============
 
 _Orchestrator_ is a MySQL replication topology management and visualization tool, allowing for:
@@ -38,7 +38,7 @@ _Orchestrator_ supports:
 - Web API (HTTP GET access)
 - Web interface, a _slick_ one.
 
-![Orcehstrator screenshot](https://github.com/github/orchestrator/wiki/images/orchestrator-introduction-screenshot.png)
+![Orcehstrator screenshot](https://github.com/outbrain/orchestrator/wiki/images/orchestrator-introduction-screenshot.png)
 
 #### More
 
@@ -49,9 +49,9 @@ _Orchestrator_ supports:
 - MySQL-Pool association
 - Run as a service; orchestrator multi-service HA
 - HTTP security/authentication methods
-- When working with [orchestrator-agent](https://github.com/github/orchestrator-agent), seed new/corrupt instances
+- When working with [orchestrator-agent](https://github.com/outbrain/orchestrator-agent), seed new/corrupt instances
 - More...
 
-Read the [Orchestrator Manual](https://github.com/github/orchestrator/wiki/Orchestrator-Manual) for comprehensive documentation.
+Read the [Orchestrator Manual](https://github.com/outbrain/orchestrator/wiki/Orchestrator-Manual) for comprehensive documentation.
 
 Authored by [Shlomi Noach](https://github.com/shlomi-noach) at [GitHub](http://github.com). Previously at [Booking.com](http://booking.com) and [Outbrain](http://outbrain.com)

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1467,7 +1467,7 @@ func (this *HttpAPI) ReloadClusterAlias(params martini.Params, r render.Render, 
 	r.JSON(200, &APIResponse{Code: OK, Message: "Cluster alias cache reloaded"})
 }
 
-// Agents provides complete list of registered agents (See https://github.com/github/orchestrator-agent)
+// Agents provides complete list of registered agents (See https://github.com/outbrain/orchestrator-agent)
 func (this *HttpAPI) Agents(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})

--- a/resources/templates/about.tmpl
+++ b/resources/templates/about.tmpl
@@ -46,7 +46,7 @@
                 <i>Orchestrator</i> is released as open source under the
                 <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 license</a>
                 and is available at:
-                <a href="https://github.com/github/orchestrator">https://github.com/github/orchestrator</a>
+                <a href="https://github.com/outbrain/orchestrator">https://github.com/outbrain/orchestrator</a>
             </p>
             <p>
                 Developed by Shlomi Noach.

--- a/resources/templates/faq.tmpl
+++ b/resources/templates/faq.tmpl
@@ -99,7 +99,7 @@
                 <i>Orchestrator</i> is released as open source under the
                 <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 license</a>
                 and is available at:
-                <a href="https://github.com/github/orchestrator">https://github.com/github/orchestrator</a>
+                <a href="https://github.com/outbrain/orchestrator">https://github.com/outbrain/orchestrator</a>
             </p>
             <p>
                 <strong>Who develops orchestrator and why?</strong>

--- a/resources/templates/layout.tmpl
+++ b/resources/templates/layout.tmpl
@@ -42,7 +42,7 @@
 						class="icon-bar"></span> <span class="icon-bar"></span> <span
 						class="icon-bar"></span>
 				</button>
-				<a class="navbar-brand orchestrator-brand" href="https://github.com/github/orchestrator">orchestrator</a>
+				<a class="navbar-brand orchestrator-brand" href="https://github.com/outbrain/orchestrator">orchestrator</a>
 
 			</div>
 			<div class="collapse navbar-collapse">
@@ -55,8 +55,8 @@
                         </a>
                         <ul class="dropdown-menu">
                             <li><a href="/web/about">About</a></li>
-                            <li><a href="https://github.com/github/orchestrator/wiki/Orchestrator-Manual" target="_blank">Manual</a></li>
-                            <li><a href="https://github.com/github/orchestrator/wiki/FAQ" target="_blank">FAQ</a></li>
+                            <li><a href="https://github.com/outbrain/orchestrator/wiki/Orchestrator-Manual" target="_blank">Manual</a></li>
+                            <li><a href="https://github.com/outbrain/orchestrator/wiki/FAQ" target="_blank">FAQ</a></li>
                             <li><a href="/web/keep-calm">Keep calm</a></li>
 		                    <li role="presentation" class="divider"></li>
                             <li><a href="/web/status">Status</a></li>


### PR DESCRIPTION
`--promotion_rule` flag now supported in `-c register-candidate`, accepts `prefer | neutral | must_not`.
- 'must_not' behavior is similar to `PromotionIgnoreHostnameFilters`
- 'neutral' means nothing
- 'prefer' is the existing behavior of preferring this instance to be promoted when possible.

This allows for preventing promotion of a server in a way that is not hostname/regex based.