### PR TITLE
Support running with semi-sync enforced.

### DIFF
--- a/conf/orchestrator-sample.conf.json
+++ b/conf/orchestrator-sample.conf.json
@@ -68,6 +68,7 @@
   "DataCenterPattern": "[.]([^.]+)[.][^.]+[.]mydomain[.]com",
   "PhysicalEnvironmentPattern": "[.]([^.]+[.][^.]+)[.]mydomain[.]com",
   "PromotionIgnoreHostnameFilters": [],
+  "DetectSemiSyncEnforcedQuery": "",
   "ServeAgentsHttp": false,
   "AgentsServerPort": ":3001",
   "AgentsUseSSL": false,

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -104,6 +104,7 @@ type Configuration struct {
 	PhysicalEnvironmentPattern                   string            // Regexp pattern with one group, extracting physical environment info from hostname (e.g. combination of datacenter & prod/dev env)
 	DetectDataCenterQuery                        string            // Optional query (executed on topology instance) that returns the data center of an instance. If provided, must return one row, one column. Overrides DataCenterPattern and useful for installments where DC cannot be inferred by hostname
 	DetectPhysicalEnvironmentQuery               string            // Optional query (executed on topology instance) that returns the physical environment of an instance. If provided, must return one row, one column. Overrides PhysicalEnvironmentPattern and useful for installments where env cannot be inferred by hostname
+	DetectSemiSyncEnforcedQuery                  string            // Optional query (executed on topology instance) to determine whether semi-sync is fully enforced for master writes (async fallback is not allowed under any circumstance). If provided, must return one row, one column, value 0 or 1.
 	SupportFuzzyPoolHostnames                    bool              // Should "submit-pool-instances" command be able to pass list of fuzzy instances (fuzzy means non-fqdn, but unique enough to recognize). Defaults 'true', implies more queries on backend db
 	PromotionIgnoreHostnameFilters               []string          // Orchestrator will not promote slaves with hostname matching pattern (via -c recovery; for example, avoid promoting dev-dedicated machines)
 	ServeAgentsHttp                              bool              // Spawn another HTTP interface dedicated for orcehstrator-agent
@@ -241,6 +242,7 @@ func newConfiguration() *Configuration {
 		PhysicalEnvironmentPattern:                   "",
 		DetectDataCenterQuery:                        "",
 		DetectPhysicalEnvironmentQuery:               "",
+		DetectSemiSyncEnforcedQuery:                  "",
 		SupportFuzzyPoolHostnames:                    true,
 		PromotionIgnoreHostnameFilters:               []string{},
 		ServeAgentsHttp:                              false,

--- a/go/db/db.go
+++ b/go/db/db.go
@@ -803,6 +803,11 @@ var generateSQLPatches = []string{
 				database_instance
 				ADD COLUMN allow_tls TINYINT UNSIGNED NOT NULL AFTER sql_delay
 	`,
+	`
+		ALTER TABLE
+			database_instance
+			ADD COLUMN semi_sync_enforced TINYINT UNSIGNED NOT NULL AFTER physical_environment
+	`,
 }
 
 // Track if a TLS has already been configured for topology

--- a/go/inst/instance.go
+++ b/go/inst/instance.go
@@ -19,10 +19,11 @@ package inst
 import (
 	"database/sql"
 	"fmt"
-	"github.com/outbrain/golib/math"
-	"github.com/outbrain/orchestrator/go/config"
 	"strconv"
 	"strings"
+
+	"github.com/outbrain/golib/math"
+	"github.com/outbrain/orchestrator/go/config"
 )
 
 // CandidatePromotionRule describe the promotion preference/rule for an instance.
@@ -80,6 +81,7 @@ type Instance struct {
 	IsCoMaster                      bool
 	HasReplicationCredentials       bool
 	ReplicationCredentialsAvailable bool
+	SemiSyncEnforced                bool
 
 	LastSeenTimestamp    string
 	IsLastCheckValid     bool

--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -332,6 +332,8 @@ function openNodeModal(node) {
   $('#node_modal button[data-btn=enable-gtid]').appendTo(td.find("div"))
   $('#node_modal button[data-btn=disable-gtid]').appendTo(td.find("div"))
 
+  addNodeModalDataAttribute("Semi-sync enforced", booleanString(node.SemiSyncEnforced));
+
   addNodeModalDataAttribute("Uptime", node.Uptime);
   addNodeModalDataAttribute("Allow TLS", node.AllowTLS);
   addNodeModalDataAttribute("Cluster",


### PR DESCRIPTION
That is, with async fallback not allowed under any circumstance for
master writes. This is accomplished, for example, by setting:

```
rpl_semi_sync_master_wait_no_slave = 1
rpl_semi_sync_master_timeout = 1000000000000000000 # "infinite"
```

When Orchestrator works with instances that use these settings, it's
important to toggle `rpl_semi_sync_master_enabled` and
`rpl_semi_sync_slave_enabled` at the right times to ensure that:

* A master must not be not allowed to accept writes until semi-sync is
  turned on.
* Slaves don't get stuck waiting for ACKs when they have no slaves of
  their own.
* Slaves with `PromotionRule: must_not` must never ACK, because if they
  win the ACK race when the master goes down, we're stuck.

Orchestrator will use the `DetectSemiSyncEnforcedQuery` config entry
(if specified) to determine if a given instance is configured in this
mode. As an example, you can set `DetectSemiSyncEnforcedQuery` to
something like this:

```
SELECT @@global.rpl_semi_sync_master_wait_no_slave AND @@global.rpl_semi_sync_master_timeout > 1000000
```

See #156 for more information.