### PR TITLE
Allow web app to work through URL-rewriting proxies.

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -108,7 +108,7 @@ type Configuration struct {
 	DetectSemiSyncEnforcedQuery                  string            // Optional query (executed on topology instance) to determine whether semi-sync is fully enforced for master writes (async fallback is not allowed under any circumstance). If provided, must return one row, one column, value 0 or 1.
 	SupportFuzzyPoolHostnames                    bool              // Should "submit-pool-instances" command be able to pass list of fuzzy instances (fuzzy means non-fqdn, but unique enough to recognize). Defaults 'true', implies more queries on backend db
 	PromotionIgnoreHostnameFilters               []string          // Orchestrator will not promote slaves with hostname matching pattern (via -c recovery; for example, avoid promoting dev-dedicated machines)
-	ServeAgentsHttp                              bool              // Spawn another HTTP interface dedicated for orcehstrator-agent
+	ServeAgentsHttp                              bool              // Spawn another HTTP interface dedicated for orchestrator-agent
 	AgentsUseSSL                                 bool              // When "true" orchestrator will listen on agents port with SSL as well as connect to agents via SSL
 	AgentsUseMutualTLS                           bool              // When "true" Use mutual TLS for the server to agent communication
 	AgentSSLSkipVerify                           bool              // When using SSL for the Agent, should we ignore SSL certification error

--- a/go/http/web.go
+++ b/go/http/web.go
@@ -56,6 +56,13 @@ func (this *HttpWeb) AccessToken(params martini.Params, r render.Render, req *ht
 	r.Redirect("/")
 }
 
+func (this *HttpWeb) Index(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+	// Redirect index so that all web URLs begin with "/web/".
+	// We also redirect /web/ to /web/clusters so that
+	// the Clusters page has a single canonical URL.
+	r.Redirect("/web/clusters")
+}
+
 func (this *HttpWeb) Clusters(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	r.HTML(200, "templates/clusters", map[string]interface{}{
 		"agentsHttpActive":              config.Config.ServeAgentsHttp,
@@ -364,8 +371,8 @@ func (this *HttpWeb) Status(params martini.Params, r render.Render, req *http.Re
 // RegisterRequests makes for the de-facto list of known Web calls
 func (this *HttpWeb) RegisterRequests(m *martini.ClassicMartini) {
 	m.Get("/web/access-token", this.AccessToken)
-	m.Get("/", this.Clusters)
-	m.Get("/web", this.Clusters)
+	m.Get("/", this.Index)
+	m.Get("/web", this.Index)
 	m.Get("/web/home", this.About)
 	m.Get("/web/about", this.About)
 	m.Get("/web/keep-calm", this.KeepCalm)

--- a/resources/public/css/orchestrator.css
+++ b/resources/public/css/orchestrator.css
@@ -8,7 +8,6 @@
 
 body {
     background-color: #eeeeee;
-    background-image: url('/images/tile.png');
     background-repeat: repeat;
     padding-top: 80px;
 }

--- a/resources/public/js/agent.js
+++ b/resources/public/js/agent.js
@@ -3,14 +3,14 @@ $(document).ready(function() {
 
   var hasActiveSeeds = false;
 
-  $.get("/api/agent/" + currentAgentHost(), function(agent) {
+  $.get(appUrl("/api/agent/" + currentAgentHost()), function(agent) {
     showLoader();
     agent.AvailableLocalSnapshots || (agent.AvailableLocalSnapshots = [])
     agent.AvailableSnapshots || (agent.AvailableSnapshots = [])
     displayAgent(agent);
   }, "json");
 
-  $.get("/api/agent-active-seeds/" + currentAgentHost(), function(activeSeeds) {
+  $.get(appUrl("/api/agent-active-seeds/" + currentAgentHost()), function(activeSeeds) {
     showLoader();
     activeSeeds.forEach(function(activeSeed) {
       appendSeedDetails(activeSeed, "[data-agent=active_seeds]");
@@ -23,7 +23,7 @@ $(document).ready(function() {
       hasActiveSeeds = true;
       activateRefreshTimer();
 
-      $.get("/api/agent-seed-states/" + activeSeeds[0].SeedId, function(seedStates) {
+      $.get(appUrl("/api/agent-seed-states/" + activeSeeds[0].SeedId), function(seedStates) {
         showLoader();
         seedStates.forEach(function(seedState) {
           appendSeedState(seedState);
@@ -31,7 +31,7 @@ $(document).ready(function() {
       }, "json");
     }
   }, "json");
-  $.get("/api/agent-recent-seeds/" + currentAgentHost(), function(recentSeeds) {
+  $.get(appUrl("/api/agent-recent-seeds/" + currentAgentHost()), function(recentSeeds) {
     showLoader();
     recentSeeds.forEach(function(recentSeed) {
       appendSeedDetails(recentSeed, "[data-agent=recent_seeds]");
@@ -48,7 +48,7 @@ $(document).ready(function() {
     }
     $("[data-agent=hostname]").html(agent.Hostname)
     $("[data-agent=hostname_search]").html(
-      '<a href="/web/search?s=' + agent.Hostname + ':' + agent.MySQLPort + '">' + agent.Hostname + '</a>' + '<div class="pull-right"><button class="btn btn-xs btn-success" data-command="discover" data-hostname="' + agent.Hostname + '" data-mysql-port="' + agent.MySQLPort + '">Discover</button></div>'
+      '<a href="' + appUrl('/web/search?s=' + agent.Hostname + ':' + agent.MySQLPort) + '">' + agent.Hostname + '</a>' + '<div class="pull-right"><button class="btn btn-xs btn-success" data-command="discover" data-hostname="' + agent.Hostname + '" data-mysql-port="' + agent.MySQLPort + '">Discover</button></div>'
     );
     $("[data-agent=port]").html(agent.Port)
     $("[data-agent=last_submitted]").html(agent.LastSubmitted)
@@ -100,7 +100,7 @@ $(document).ready(function() {
         }
         var isLocal = $.inArray(hostname, agent.AvailableLocalSnapshots) >= 0;
         var btnType = (isLocal ? "btn-success" : "btn-warning");
-        return '<td><a href="/web/agent/' + hostname + '">' + hostname + '</a><div class="pull-right"><button class="btn btn-xs ' + btnType + '" data-command="seed" data-seed-source-host="' + hostname + '" data-seed-local="' + isLocal + '" data-mysql-running="' + agent.MySQLRunning + '">Seed</button></div></td>';
+        return '<td><a href="' + appUrl('/web/agent/' + hostname) + '">' + hostname + '</a><div class="pull-right"><button class="btn btn-xs ' + btnType + '" data-command="seed" data-seed-source-host="' + hostname + '" data-seed-local="' + isLocal + '" data-mysql-running="' + agent.MySQLRunning + '">Seed</button></div></td>';
       });
       result = result.map(function(entry) {
         return '<tr>' + entry + '</tr>';
@@ -170,7 +170,7 @@ $(document).ready(function() {
       return;
     }
     showLoader();
-    $.get("/api/agent-umount/" + currentAgentHost(), function(operationResult) {
+    $.get(appUrl("/api/agent-umount/" + currentAgentHost()), function(operationResult) {
       hideLoader();
       if (operationResult.Code == "ERROR") {
         addAlert(operationResult.Message)
@@ -182,7 +182,7 @@ $(document).ready(function() {
   $("body").on("click", "button[data-command=mountlv]", function(event) {
     var lv = $(event.target).attr("data-lv")
     showLoader();
-    $.get("/api/agent-mount/" + currentAgentHost() + "?lv=" + encodeURIComponent(lv), function(operationResult) {
+    $.get(appUrl("/api/agent-mount/" + currentAgentHost() + "?lv=" + encodeURIComponent(lv)), function(operationResult) {
       hideLoader();
       if (operationResult.Code == "ERROR") {
         addAlert(operationResult.Message)
@@ -197,7 +197,7 @@ $(document).ready(function() {
     bootbox.confirm(message, function(confirm) {
       if (confirm) {
         showLoader();
-        $.get("/api/agent-removelv/" + currentAgentHost() + "?lv=" + encodeURIComponent(lv), function(operationResult) {
+        $.get(appUrl("/api/agent-removelv/" + currentAgentHost() + "?lv=" + encodeURIComponent(lv)), function(operationResult) {
           hideLoader();
           if (operationResult.Code == "ERROR") {
             addAlert(operationResult.Message)
@@ -214,7 +214,7 @@ $(document).ready(function() {
     bootbox.confirm(message, function(confirm) {
       if (confirm) {
         showLoader();
-        $.get("/api/agent-create-snapshot/" + currentAgentHost(), function(operationResult) {
+        $.get(appUrl("/api/agent-create-snapshot/" + currentAgentHost()), function(operationResult) {
           hideLoader();
           if (operationResult.Code == "ERROR") {
             addAlert(operationResult.Message)
@@ -231,7 +231,7 @@ $(document).ready(function() {
     bootbox.confirm(message, function(confirm) {
       if (confirm) {
         showLoader();
-        $.get("/api/agent-mysql-stop/" + currentAgentHost(), function(operationResult) {
+        $.get(appUrl("/api/agent-mysql-stop/" + currentAgentHost()), function(operationResult) {
           hideLoader();
           if (operationResult.Code == "ERROR") {
             addAlert(operationResult.Message)
@@ -244,7 +244,7 @@ $(document).ready(function() {
   });
   $("body").on("click", "button[data-command=mysql-start]", function(event) {
     showLoader();
-    $.get("/api/agent-mysql-start/" + currentAgentHost(), function(operationResult) {
+    $.get(appUrl("/api/agent-mysql-start/" + currentAgentHost()), function(operationResult) {
       hideLoader();
       if (operationResult.Code == "ERROR") {
         addAlert(operationResult.Message)
@@ -277,7 +277,7 @@ $(document).ready(function() {
     bootbox.confirm(message, function(confirm) {
       if (confirm) {
         showLoader();
-        $.get("/api/agent-seed/" + currentAgentHost() + "/" + sourceHost, function(operationResult) {
+        $.get(appUrl("/api/agent-seed/" + currentAgentHost() + "/" + sourceHost), function(operationResult) {
           hideLoader();
           if (operationResult.Code == "ERROR") {
             addAlert(operationResult.Message)

--- a/resources/public/js/agents.js
+++ b/resources/public/js/agents.js
@@ -3,7 +3,7 @@ $(document).ready(function () {
     showLoader();
     activateRefreshTimer();
     
-    $.get("/api/agents", function (agents) {
+    $.get(appUrl("/api/agents"), function (agents) {
     	displayAgents(agents);
     }, "json");
     function displayAgents(agents) {
@@ -15,7 +15,7 @@ $(document).ready(function () {
     		//var title = agent.Hostname;
     		//popoverElement.find("h3 a").html(title);
     	    var contentHtml = ''
-    	    	+ '<a href="/web/agent/'+ agent.Hostname +'" class="small">'
+    	    	+ '<a href="' + appUrl('/web/agent/'+ agent.Hostname) +'" class="small">'
     	    	+ agent.Hostname
     	    	+ '</a>'
     			;

--- a/resources/public/js/audit-failure-detection.js
+++ b/resources/public/js/audit-failure-detection.js
@@ -4,8 +4,8 @@ $(document).ready(function() {
   if (detectionId() > 0) {
     uri = "/api/audit-failure-detection/id/" + detectionId();
   }
-  $.get(uri, function(auditEntries) {
-    $.get("/api/replication-analysis-changelog", function(analysisChangelog) {
+  $.get(appUrl(uri), function(auditEntries) {
+    $.get(appUrl("/api/replication-analysis-changelog"), function(analysisChangelog) {
       displayAudit(auditEntries, analysisChangelog);
     }, "json");
   }, "json");
@@ -28,18 +28,18 @@ $(document).ready(function() {
       }).prepend(moreInfoElement).appendTo(row);
       $('<a/>', {
         text: analyzedInstanceDisplay,
-        href: "/web/search/" + analyzedInstanceDisplay
+        href: appUrl("/web/search/" + analyzedInstanceDisplay)
       }).wrap($("<td/>")).parent().appendTo(row);
       $('<td/>', {
         text: audit.AnalysisEntry.CountSlaves
       }).appendTo(row);
       $('<a/>', {
         text: audit.AnalysisEntry.ClusterDetails.ClusterName,
-        href: "/web/cluster/" + audit.AnalysisEntry.ClusterDetails.ClusterName
+        href: appUrl("/web/cluster/" + audit.AnalysisEntry.ClusterDetails.ClusterName)
       }).wrap($("<td/>")).parent().appendTo(row);
       $('<a/>', {
         text: audit.AnalysisEntry.ClusterDetails.ClusterAlias,
-        href: "/web/cluster/alias/" + audit.AnalysisEntry.ClusterDetails.ClusterAlias
+        href: appUrl("/web/cluster/alias/" + audit.AnalysisEntry.ClusterDetails.ClusterAlias)
       }).wrap($("<td/>")).parent().appendTo(row);
       $('<td/>', {
         text: audit.RecoveryStartTimestamp
@@ -70,7 +70,7 @@ $(document).ready(function() {
         });
         moreInfo += "</ul></div>";
       }
-      moreInfo += '<div><a href="/web/audit-recovery/id/' + audit.RelatedRecoveryId + '">Related recovery</a></div>';
+      moreInfo += '<div><a href="' + appUrl('/web/audit-recovery/id/' + audit.RelatedRecoveryId) + '">Related recovery</a></div>';
 
       moreInfo += "<div>Proccessed by <code>" + audit.ProcessingNodeHostname + "</code></div>";
       row.appendTo('#audit tbody');
@@ -91,10 +91,10 @@ $(document).ready(function() {
       $("#audit .pager .next").addClass("disabled");
     }
     $("#audit .pager .previous").not(".disabled").find("a").click(function() {
-      window.location.href = "/web/audit-failure-detection/" + (currentPage() - 1);
+      window.location.href = appUrl("/web/audit-failure-detection/" + (currentPage() - 1));
     });
     $("#audit .pager .next").not(".disabled").find("a").click(function() {
-      window.location.href = "/web/audit-failure-detection/" + (currentPage() + 1);
+      window.location.href = appUrl("/web/audit-failure-detection/" + (currentPage() + 1));
     });
     $("#audit .pager .disabled a").click(function() {
       return false;

--- a/resources/public/js/audit-recovery.js
+++ b/resources/public/js/audit-recovery.js
@@ -7,12 +7,12 @@ $(document).ready(function() {
   if (recoveryId() > 0) {
     apiUri = "/api/audit-recovery/id/" + recoveryId();
   }
-  $.get(apiUri, function(auditEntries) {
+  $.get(appUrl(apiUri), function(auditEntries) {
     displayAudit(auditEntries);
   }, "json");
 
   function displayAudit(auditEntries) {
-    var baseWebUri = "/web/audit-recovery/";
+    var baseWebUri = appUrl("/web/audit-recovery/");
     if (auditCluster()) {
       baseWebUri += "cluster/" + auditCluster() + "/";
     }
@@ -40,18 +40,18 @@ $(document).ready(function() {
       }).prepend(ack).prepend(moreInfoElement).appendTo(row);
       $('<a/>', {
         text: analyzedInstanceDisplay,
-        href: "/web/search/" + analyzedInstanceDisplay
+        href: appUrl("/web/search/" + analyzedInstanceDisplay)
       }).wrap($("<td/>")).parent().appendTo(row);
       $('<td/>', {
         text: audit.AnalysisEntry.CountSlaves
       }).appendTo(row);
       $('<a/>', {
         text: audit.AnalysisEntry.ClusterDetails.ClusterName,
-        href: "/web/cluster/" + audit.AnalysisEntry.ClusterDetails.ClusterName
+        href: appUrl("/web/cluster/" + audit.AnalysisEntry.ClusterDetails.ClusterName)
       }).wrap($("<td/>")).parent().appendTo(row);
       $('<a/>', {
         text: audit.AnalysisEntry.ClusterDetails.ClusterAlias,
-        href: "/web/cluster/alias/" + audit.AnalysisEntry.ClusterDetails.ClusterAlias
+        href: appUrl("/web/cluster/alias/" + audit.AnalysisEntry.ClusterDetails.ClusterAlias)
       }).wrap($("<td/>")).parent().appendTo(row);
       $('<td/>', {
         text: audit.RecoveryStartTimestamp
@@ -66,7 +66,7 @@ $(document).ready(function() {
       } else if (audit.SuccessorKey.Hostname) {
         $('<a/>', {
           text: sucessorInstanceDisplay,
-          href: "/web/search/" + sucessorInstanceDisplay
+          href: appUrl("/web/search/" + sucessorInstanceDisplay)
         }).wrap($("<td/>")).parent().appendTo(row);
       } else {
         $('<td/>', {
@@ -109,7 +109,7 @@ $(document).ready(function() {
         });
         moreInfo += "</ul>";
       }
-      moreInfo += '<div><a href="/web/audit-failure-detection/id/' + audit.LastDetectionId + '">Related detection</a></div>';
+      moreInfo += '<div><a href="' + appUrl('/web/audit-failure-detection/id/' + audit.LastDetectionId) + '">Related detection</a></div>';
       moreInfo += '<div>Proccessed by <code>' + audit.ProcessingNodeHostname + '</code></div>';
       row.appendTo('#audit tbody');
 
@@ -152,7 +152,7 @@ $(document).ready(function() {
         callback: function(result) {
           if (result !== null) {
             showLoader();
-            $.get("/api/ack-recovery/" + recoveryId + "?comment=" + encodeURIComponent(result), function(operationResult) {
+            $.get(appUrl("/api/ack-recovery/" + recoveryId + "?comment=" + encodeURIComponent(result)), function(operationResult) {
               hideLoader();
               if (operationResult.Code == "ERROR") {
                 addAlert(operationResult.Message)

--- a/resources/public/js/audit.js
+++ b/resources/public/js/audit.js
@@ -5,11 +5,11 @@ $(document).ready(function () {
     if (auditHostname()) {
     	apiUri = "/api/audit/instance/"+auditHostname()+"/"+auditPort()+"/"+currentPage();
     }
-    $.get(apiUri, function (auditEntries) {
+    $.get(appUrl(apiUri), function (auditEntries) {
             displayAudit(auditEntries);
     	}, "json");
     function displayAudit(auditEntries) {
-    	var baseWebUri = "/web/audit/";
+    	var baseWebUri = appUrl("/web/audit/");
     	if (auditHostname()) {
     		baseWebUri += "instance/"+auditHostname()+"/"+auditPort()+"/";
         }
@@ -19,7 +19,7 @@ $(document).ready(function () {
     		jQuery('<td/>', { text: audit.AuditTimestamp }).appendTo(row);
     		jQuery('<td/>', { text: audit.AuditType }).appendTo(row);
     		if (audit.AuditInstanceKey.Hostname) {
-    			var uri = "/web/audit/instance/"+audit.AuditInstanceKey.Hostname+"/"+audit.AuditInstanceKey.Port;
+    			var uri = appUrl("/web/audit/instance/"+audit.AuditInstanceKey.Hostname+"/"+audit.AuditInstanceKey.Port);
     			$('<a/>',  { text: audit.AuditInstanceKey.Hostname+":"+audit.AuditInstanceKey.Port , href: uri}).wrap($("<td/>")).parent().appendTo(row);
     		} else {
     			jQuery('<td/>', { text: audit.AuditInstanceKey.Hostname+":"+audit.AuditInstanceKey.Port }).appendTo(row);

--- a/resources/public/js/cluster-pools.js
+++ b/resources/public/js/cluster-pools.js
@@ -26,8 +26,8 @@ $(document).ready(function() {
     }
   };
 
-  $.get("/api/cluster-pool-instances/" + currentClusterName(), function(clusterPoolInstances) {
-    $.get("/api/problems", function(problemInstances) {
+  $.get(appUrl("/api/cluster-pool-instances/" + currentClusterName()), function(clusterPoolInstances) {
+    $.get(appUrl("/api/problems"), function(problemInstances) {
       var problemInstancesMap = normalizeInstances(problemInstances, []);
       displayClusterPoolInstances(clusterPoolInstances, problemInstances, problemInstancesMap);
     }, "json");
@@ -137,7 +137,7 @@ $(document).ready(function() {
     activateRefreshTimer();
   }
   $("#dropdown-context").append('<li><a data-command="expand-instances">Expand</a></li>');
-  $("#dropdown-context").append('<li><a href="/web/cluster/' + currentClusterName() + '">Topology</a></li>');
+  $("#dropdown-context").append('<li><a href="' + appUrl('/web/cluster/' + currentClusterName()) + '">Topology</a></li>');
   $("body").on("click", "a[data-command=expand-instances]", function(event) {
     isExpanded = !isExpanded;
     updateExpandedStatus();

--- a/resources/public/js/cluster.js
+++ b/resources/public/js/cluster.js
@@ -1290,7 +1290,7 @@ function Cluster() {
       var content = 'Heuristic lag: ' + clusterInfo.HeuristicLag + 's';
       addSidebarInfoPopoverContent(content, false);
     } {
-      var content = '<a href="/web/audit-recovery/cluster/' + clusterInfo.ClusterName + '">Recovery history</a>';
+      var content = '<a href="' + appUrl('/web/audit-recovery/cluster/' + clusterInfo.ClusterName) + '">Recovery history</a>';
       addSidebarInfoPopoverContent(content, false);
     } {
       var content = '';
@@ -1551,7 +1551,7 @@ function Cluster() {
         $("#cluster_container").append('<div class="floating_background">' + visualAlias + '</div>');
         $("#dropdown-context").append('<li><a data-command="change-cluster-alias" data-alias="' + clusterInfo.ClusterAlias + '">Alias: ' + alias + '</a></li>');
       }
-      $("#dropdown-context").append('<li><a href="/web/cluster-pools/' + currentClusterName() + '">Pools</a></li>');
+      $("#dropdown-context").append('<li><a href="' + appUrl('/web/cluster-pools/' + currentClusterName()) + '">Pools</a></li>');
       if (isCompactDisplay()) {
         $("#dropdown-context").append('<li><a data-command="expand-display" href="' + location.href.split("?")[0].split("#")[0] + '?compact=false"><span class="glyphicon glyphicon-ok small"></span> Compact display</a></li>');
       } else {
@@ -1575,19 +1575,19 @@ function Cluster() {
     getData("/api/active-cluster-recovery/" + currentClusterName(), function(recoveries) {
       // Result is an array: either empty (no active recovery) or with multiple entries
       recoveries.forEach(function(recoveryEntry) {
-        addInfo('<strong><a href="/web/audit-recovery/cluster/' + currentClusterName() + '">' + recoveryEntry.AnalysisEntry.Analysis + ' active recovery in progress</strong></a>. Topology is subject to change in the next moments.');
+        addInfo('<strong><a href="' + appUrl('/web/audit-recovery/cluster/' + currentClusterName()) + '">' + recoveryEntry.AnalysisEntry.Analysis + ' active recovery in progress</strong></a>. Topology is subject to change in the next moments.');
       });
     });
     getData("/api/recently-active-cluster-recovery/" + currentClusterName(), function(recoveries) {
       // Result is an array: either empty (no active recovery) or with multiple entries
       recoveries.forEach(function(recoveryEntry) {
-        addInfo('This cluster just recently (' + recoveryEntry.RecoveryEndTimestamp + ') recovered from <strong><a href="/web/audit-recovery/cluster/' + currentClusterName() + '">' + recoveryEntry.AnalysisEntry.Analysis + '</strong></a>. It may still take some time to rebuild topology graph.');
+        addInfo('This cluster just recently (' + recoveryEntry.RecoveryEndTimestamp + ') recovered from <strong><a href="' + appUrl('/web/audit-recovery/cluster/' + currentClusterName()) + '">' + recoveryEntry.AnalysisEntry.Analysis + '</strong></a>. It may still take some time to rebuild topology graph.');
       });
     });
     getData("/api/blocked-recoveries/cluster/" + currentClusterName(), function(blockedRecoveries) {
       // Result is an array: either empty (no active recovery) or with multiple entries
       blockedRecoveries.forEach(function(blockedRecovery) {
-        addAlert('A <strong>' + blockedRecovery.Analysis + '</strong> on ' + getInstanceTitle(blockedRecovery.FailedInstanceKey.Hostname, blockedRecovery.FailedInstanceKey.Port) + ' is blocked due to a <a href="/web/audit-recovery/cluster/' + blockedRecovery.ClusterName + '">previous recovery</a>');
+        addAlert('A <strong>' + blockedRecovery.Analysis + '</strong> on ' + getInstanceTitle(blockedRecovery.FailedInstanceKey.Hostname, blockedRecovery.FailedInstanceKey.Port) + ' is blocked due to a <a href="' + appUrl('/web/audit-recovery/cluster/' + blockedRecovery.ClusterName) + '">previous recovery</a>');
       });
     });
     getData("/api/cluster-osc-slaves/" + currentClusterName(), function(instances) {
@@ -1676,7 +1676,7 @@ function Cluster() {
 
 
   function getData(url, cb) {
-    $.get(url, cb, "json");
+    $.get(appUrl(url), cb, "json");
   }
 
 

--- a/resources/public/js/clusters-analysis.js
+++ b/resources/public/js/clusters-analysis.js
@@ -1,17 +1,17 @@
 $(document).ready(function() {
   showLoader();
 
-  $.get("/api/clusters-info", function(clusters) {
-    $.get("/api/replication-analysis", function(replicationAnalysis) {
-      $.get("/api/blocked-recoveries", function(blockedRecoveries) {
+  $.get(appUrl("/api/clusters-info"), function(clusters) {
+    $.get(appUrl("/api/replication-analysis"), function(replicationAnalysis) {
+      $.get(appUrl("/api/blocked-recoveries"), function(blockedRecoveries) {
         displayClustersAnalysis(clusters, replicationAnalysis, blockedRecoveries);
       }, "json");
     }, "json");
   }, "json");
-  $.get("/api/blocked-recoveries", function(blockedRecoveries) {
+  $.get(appUrl("/api/blocked-recoveries"), function(blockedRecoveries) {
     // Result is an array: either empty (no active recovery) or with multiple entries
     blockedRecoveries.forEach(function(blockedRecovery) {
-      addAlert('A <strong>' + blockedRecovery.Analysis + '</strong> on ' + getInstanceTitle(blockedRecovery.FailedInstanceKey.Hostname, blockedRecovery.FailedInstanceKey.Port) + ' is blocked due to a <a href="/web/audit-recovery/cluster/' + blockedRecovery.ClusterName + '">previous recovery</a>');
+      addAlert('A <strong>' + blockedRecovery.Analysis + '</strong> on ' + getInstanceTitle(blockedRecovery.FailedInstanceKey.Hostname, blockedRecovery.FailedInstanceKey.Port) + ' is blocked due to a <a href="' + appUrl('/web/audit-recovery/cluster/' + blockedRecovery.ClusterName) + '">previous recovery</a>');
     });
   });
 
@@ -91,7 +91,7 @@ $(document).ready(function() {
     }
 
     function displayCluster(cluster) {
-      $("#clusters_analysis").append('<div xmlns="http://www.w3.org/1999/xhtml" class="popover instance right" data-cluster-name="' + cluster.ClusterName + '"><div class="arrow"></div><h3 class="popover-title"><div class="pull-left"><a href="/web/cluster/' + cluster.ClusterName + '"><span>' + cluster.ClusterName + '</span></a></div><div class="pull-right"></div>&nbsp;<br/>&nbsp;</h3><div class="popover-content"><div></div></div></div>');
+      $("#clusters_analysis").append('<div xmlns="http://www.w3.org/1999/xhtml" class="popover instance right" data-cluster-name="' + cluster.ClusterName + '"><div class="arrow"></div><h3 class="popover-title"><div class="pull-left"><a href="' + appUrl('/web/cluster/' + cluster.ClusterName) + '"><span>' + cluster.ClusterName + '</span></a></div><div class="pull-right"></div>&nbsp;<br/>&nbsp;</h3><div class="popover-content"><div></div></div></div>');
       var popoverElement = $("#clusters_analysis [data-cluster-name='" + cluster.ClusterName + "'].popover");
 
       if (typeof removeTextFromHostnameDisplay != "undefined" && removeTextFromHostnameDisplay()) {
@@ -100,8 +100,8 @@ $(document).ready(function() {
       }
       if (cluster.ClusterAlias != "") {
         popoverElement.find("h3 .pull-left a span").addClass("small");
-        popoverElement.find("h3 .pull-left").prepend('<a href="/web/cluster/alias/' + encodeURIComponent(cluster.ClusterAlias) + '"><strong>' + cluster.ClusterAlias + '</strong></a><br/>');
-        popoverElement.find("h3 .pull-right").append('<a href="/web/cluster/alias/' + encodeURIComponent(cluster.ClusterAlias) + '?compact=true"><span class="glyphicon glyphicon-compressed" title="Compact display"></span></a>');
+        popoverElement.find("h3 .pull-left").prepend('<a href="' + appUrl('/web/cluster/alias/' + encodeURIComponent(cluster.ClusterAlias)) + '"><strong>' + cluster.ClusterAlias + '</strong></a><br/>');
+        popoverElement.find("h3 .pull-right").append('<a href="' + appUrl('/web/cluster/alias/' + encodeURIComponent(cluster.ClusterAlias) + '?compact=true') + '"><span class="glyphicon glyphicon-compressed" title="Compact display"></span></a>');
       }
       displayInstancesBadge(popoverElement, "Instances", cluster.CountInstances, "label-primary", "Total instances in cluster");
 

--- a/resources/public/js/clusters.js
+++ b/resources/public/js/clusters.js
@@ -24,9 +24,9 @@ $(document).ready(function() {
     }
   };
 
-  $.get("/api/clusters-info", function(clusters) {
-    $.get("/api/replication-analysis", function(replicationAnalysis) {
-      $.get("/api/problems", function(problemInstances) {
+  $.get(appUrl("/api/clusters-info"), function(clusters) {
+    $.get(appUrl("/api/replication-analysis"), function(replicationAnalysis) {
+      $.get(appUrl("/api/problems"), function(problemInstances) {
         if (problemInstances == null) {
           problemInstances = [];
         }
@@ -97,18 +97,18 @@ $(document).ready(function() {
     });
 
     clusters.forEach(function(cluster) {
-      $("#clusters").append('<div xmlns="http://www.w3.org/1999/xhtml" class="popover instance right" data-cluster-name="' + cluster.ClusterName + '"><div class="arrow"></div><h3 class="popover-title"><div class="pull-left"><a href="/web/cluster/' + cluster.ClusterName + '"><span>' + cluster.ClusterName + '</span></a></div><div class="pull-right"></div>&nbsp;<br/>&nbsp;</h3><div class="popover-content"></div></div>');
+      $("#clusters").append('<div xmlns="http://www.w3.org/1999/xhtml" class="popover instance right" data-cluster-name="' + cluster.ClusterName + '"><div class="arrow"></div><h3 class="popover-title"><div class="pull-left"><a href="' + appUrl('/web/cluster/' + cluster.ClusterName) + '"><span>' + cluster.ClusterName + '</span></a></div><div class="pull-right"></div>&nbsp;<br/>&nbsp;</h3><div class="popover-content"></div></div>');
       var popoverElement = $("#clusters [data-cluster-name='" + cluster.ClusterName + "'].popover");
 
       if (typeof removeTextFromHostnameDisplay != "undefined" && removeTextFromHostnameDisplay()) {
         var title = cluster.ClusterName.replace(removeTextFromHostnameDisplay(), '');
         popoverElement.find("h3 .pull-left a span").html(title);
       }
-      var compactClusterUri = '/web/cluster/' + cluster.ClusterName + '?compact=true';
+      var compactClusterUri = appUrl('/web/cluster/' + cluster.ClusterName + '?compact=true');
       if (cluster.ClusterAlias) {
         popoverElement.find("h3 .pull-left a span").addClass("small");
-        popoverElement.find("h3 .pull-left").prepend('<a href="/web/cluster/alias/' + encodeURIComponent(cluster.ClusterAlias) + '"><strong>' + cluster.ClusterAlias + '</strong></a><br/>');
-        compactClusterUri = '/web/cluster/alias/' + encodeURIComponent(cluster.ClusterAlias) + '?compact=true';
+        popoverElement.find("h3 .pull-left").prepend('<a href="' + appUrl('/web/cluster/alias/' + encodeURIComponent(cluster.ClusterAlias)) + '"><strong>' + cluster.ClusterAlias + '</strong></a><br/>');
+        compactClusterUri = appUrl('/web/cluster/alias/' + encodeURIComponent(cluster.ClusterAlias) + '?compact=true');
       }
       if (clustersAnalysisProblems[cluster.ClusterName]) {
         clustersAnalysisProblems[cluster.ClusterName].forEach(function(analysisEntry) {

--- a/resources/public/js/discover.js
+++ b/resources/public/js/discover.js
@@ -18,13 +18,13 @@ $(document).ready(function () {
 function discover(hostname, port) {
     showLoader();
     var uri = "/api/discover/"+hostname+"/"+port;
-    $.get(uri, function (operationResult) {
+    $.get(appUrl(uri), function (operationResult) {
         hideLoader();
         if (operationResult.Code == "ERROR" || operationResult.Details == null) {
             addAlert(operationResult.Message)
         } else {
         	var instance = operationResult.Details;
-            addInfo('Discovered <a href="/web/search?s='+instance.Key.Hostname+":"+instance.Key.Port+'" class="alert-link">'
+            addInfo('Discovered <a href="' + appUrl('/web/search?s='+instance.Key.Hostname+":"+instance.Key.Port) + '" class="alert-link">'
             		+instance.Key.Hostname+":"+instance.Key.Port+'</a>'
             	);
         }   

--- a/resources/public/js/instance-problems.js
+++ b/resources/public/js/instance-problems.js
@@ -5,11 +5,11 @@ $(document).ready(function() {
   if (typeof currentClusterName != "undefined") {
     problemsURI += "/" + currentClusterName();
   }
-  $.get(problemsURI, function(instances) {
+  $.get(appUrl(problemsURI), function(instances) {
     if (instances == null) {
       instances = [];
     }
-    $.get("/api/maintenance", function(maintenanceList) {
+    $.get(appUrl("/api/maintenance"), function(maintenanceList) {
       normalizeInstances(instances, maintenanceList);
       displayProblemInstances(instances);
     }, "json");

--- a/resources/public/js/long-queries.js
+++ b/resources/public/js/long-queries.js
@@ -1,7 +1,7 @@
 
 $(document).ready(function () {
     showLoader();
-    $.get("/api/long-queries/"+currentFilter(), function (processes) {
+    $.get(appUrl("/api/long-queries/"+currentFilter()), function (processes) {
             displayProcesses(processes);
             if (isAuthorizedForAction()) {
             	// Read-only users don't get auto-refresh. Sorry!
@@ -19,7 +19,7 @@ $(document).ready(function () {
         		$("#long_queries tbody:last").append('<tr><td>'+title+'</td><td><code class="text-primary"><strong>'+value+'</strong></code></td></tr>')
         	}
         	
-        	addInfo('Instance', '<a href="https://orchestrator/web/search?s='+process.InstanceHostname+':'+process.InstancePort+'"><code class="text-primary">'+process.InstanceHostname+":"+process.InstancePort+'</code></a>');
+        	addInfo('Instance', '<a href="' + appUrl('/web/search?s='+process.InstanceHostname+':'+process.InstancePort) + '"><code class="text-primary">'+process.InstanceHostname+":"+process.InstancePort+'</code></a>');
         	addInfo('Process ID <siv class="pull-right"><button class="btn btn-xs btn-danger" data-command="kill_query" data-host="'+process.InstanceHostname+'" data-port="'+process.InstancePort+'" data-process="'+process.Id+'">Kill query</button></div>', process.Id);
         	addInfo('Started at', process.StartedAt);
         	addInfo('Runtime seconds', process.Time);
@@ -28,7 +28,7 @@ $(document).ready(function () {
         	/*
         	var rowDiv = jQuery('<div class="row col-xs-12"/>');
         	var infoDiv = jQuery('<div/>');
-        	infoDiv.html(infoDiv.html() + '<div><a href="https://orchestrator/web/search?s='+process.InstanceHostname+":"+process.InstancePort+'"><code class="text-primary">'+process.InstanceHostname+":"+process.InstancePort+'</code></a></div>');
+        	infoDiv.html(infoDiv.html() + '<div><a href="' + appUrl('/web/search?s='+process.InstanceHostname+":"+process.InstancePort) + '"><code class="text-primary">'+process.InstanceHostname+":"+process.InstancePort+'</code></a></div>');
         	infoDiv.html(infoDiv.html() + '<div>Id: '+process.Id+'</div>');
         	infoDiv.html(infoDiv.html() + '<div>Started: '+process.StartedAt+'</div>');
         	infoDiv.html(infoDiv.html() + '<div>Time: '+process.Time+'</div>');
@@ -47,7 +47,7 @@ $(document).ready(function () {
     	bootbox.confirm(message, function(confirm) {
 			if (confirm) {
 		    	showLoader();
-		        $.get("/api/kill-query/"+host + "/" + port + "/" + processId, function (operationResult) {
+		        $.get(appUrl("/api/kill-query/"+host + "/" + port + "/" + processId), function (operationResult) {
 					hideLoader();
 					if (operationResult.Code == "ERROR") {
 						addAlert(operationResult.Message)

--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -78,16 +78,29 @@ function hideLoader() {
   $(".ajaxLoader").css('visibility', 'hidden');
 }
 
+function appUrl(url) {
+  // Create an absolute URL that respects URL-rewriting proxies,
+  // such as the Kubernetes apiserver proxy.
+  var here = window.location.pathname;
+  var pos = here.lastIndexOf('/web/');
+  if (pos < 0) {
+    return url;
+  }
+  // This assumes the Orchestrator UI is accessed as ".../web/...".
+  // The part before the "/web/" should be prefixed onto any URLs we write.
+  return here.substr(0, pos) + url;
+}
+
 function visualizeBrand() {
   var img = $("<img>");
 
-  img.attr("src", "/images/octocat-logo-32.png").attr("alt", "GitHub");
+  img.attr("src", appUrl("/images/octocat-logo-32.png")).attr("alt", "GitHub");
 
   if (document.domain && document.domain.indexOf("outbrain.com") >= 0) {
-    img.attr("src", "/images/outbrain-logo-32.png").attr("alt", "Outbrain");
+    img.attr("src", appUrl("/images/outbrain-logo-32.png")).attr("alt", "Outbrain");
   }
   if (document.domain && document.domain.indexOf("booking.com") >= 0) {
-    img.attr("src", "/images/booking-logo-32.png").attr("alt", "Booking.com");
+    img.attr("src", appUrl("/images/booking-logo-32.png")).attr("alt", "Booking.com");
   }
   $(".orchestrator-brand").prepend(img)
 }
@@ -177,7 +190,7 @@ function addInfo(alertText) {
 
 function apiCommand(uri, hint) {
   showLoader();
-  $.get(uri, function(operationResult) {
+  $.get(appUrl(uri), function(operationResult) {
     hideLoader();
     if (operationResult.Code == "ERROR") {
       addAlert(operationResult.Message)
@@ -279,7 +292,7 @@ function openNodeModal(node) {
 
     var masterCoordinatesEl = addNodeModalDataAttribute("Master coordinates", node.ExecBinlogCoordinates.LogFile + ":" + node.ExecBinlogCoordinates.LogPos);
     $('#node_modal [data-btn-group=move-equivalent] ul').empty();
-    $.get("/api/master-equivalent/" + node.MasterKey.Hostname + "/" + node.MasterKey.Port + "/" + node.ExecBinlogCoordinates.LogFile + "/" + node.ExecBinlogCoordinates.LogPos, function(equivalenceResult) {
+    $.get(appUrl("/api/master-equivalent/") + node.MasterKey.Hostname + "/" + node.MasterKey.Port + "/" + node.ExecBinlogCoordinates.LogFile + "/" + node.ExecBinlogCoordinates.LogPos, function(equivalenceResult) {
       if (!equivalenceResult.Details) {
         return false;
       }
@@ -340,13 +353,13 @@ function openNodeModal(node) {
   addNodeModalDataAttribute("Uptime", node.Uptime);
   addNodeModalDataAttribute("Allow TLS", node.AllowTLS);
   addNodeModalDataAttribute("Cluster",
-    '<a href="/web/cluster/' + node.ClusterName + '">' + node.ClusterName + '</a>');
+    '<a href="' + appUrl('/web/cluster/' + node.ClusterName) + '">' + node.ClusterName + '</a>');
   addNodeModalDataAttribute("Audit",
-    '<a href="/web/audit/instance/' + node.Key.Hostname + '/' + node.Key.Port + '">' + node.title + '</a>');
+    '<a href="' + appUrl('/web/audit/instance/' + node.Key.Hostname + '/' + node.Key.Port) + '">' + node.title + '</a>');
   addNodeModalDataAttribute("Agent",
-    '<a href="/web/agent/' + node.Key.Hostname + '">' + node.Key.Hostname + '</a>');
+    '<a href="' + appUrl('/web/agent/' + node.Key.Hostname) + '">' + node.Key.Hostname + '</a>');
   addNodeModalDataAttribute("Long queries",
-    '<a href="/web/long-queries?filter=' + node.Key.Hostname + '">on ' + node.Key.Hostname + '</a>');
+    '<a href="' + appUrl('/web/long-queries?filter=' + node.Key.Hostname) + '">on ' + node.Key.Hostname + '</a>');
 
   $('#node_modal [data-btn]').unbind("click");
 
@@ -842,7 +855,7 @@ function renderInstanceElement(popoverElement, instance, renderType) {
       contentHtml += '<p><strong>Master</strong></p>';
     }
     if (renderType == "search") {
-      contentHtml += '<p>' + 'Cluster: <a href="/web/cluster/' + instance.ClusterName + '">' + instance.ClusterName + '</a>' + '</p>';
+      contentHtml += '<p>' + 'Cluster: <a href="' + appUrl('/web/cluster/' + instance.ClusterName) + '">' + instance.ClusterName + '</a>' + '</p>';
     }
     if (renderType == "problems") {
       contentHtml += '<p>' + 'Problem: <strong title="' + instance.problemDescription + '">' + instance.problem.replace(/_/g, ' ') + '</strong>' + '</p>';
@@ -886,14 +899,16 @@ function getParameterByName(name) {
 $(document).ready(function() {
   visualizeBrand();
 
+  $('body').css('background-image', 'url(' + appUrl('/images/tile.png') + ')');
+
   $(".navbar-nav li").removeClass("active");
   $(".navbar-nav li[data-nav-page='" + activePage() + "']").addClass("active");
 
-  $.get("/api/clusters-info", function(clusters) {
+  $.get(appUrl("/api/clusters-info"), function(clusters) {
     clusters.forEach(function(cluster) {
       var title = '<span class="small">' + cluster.ClusterName + '</span>';
       title = ((cluster.ClusterAlias != "") ? '<strong>' + cluster.ClusterAlias + '</strong>, ' + title : title);
-      $("#dropdown-clusters").append('<li><a href="/web/cluster/' + cluster.ClusterName + '">' + title + '</a></li>');
+      $("#dropdown-clusters").append('<li><a href="' + appUrl('/web/cluster/' + cluster.ClusterName) + '">' + title + '</a></li>');
     });
     onClustersListeners.forEach(function(func) {
       func(clusters);

--- a/resources/public/js/search.js
+++ b/resources/public/js/search.js
@@ -4,8 +4,8 @@ $(document).ready(function () {
 	
 	
     showLoader();
-    $.get("/api/search/"+currentSearchString(), function (instances) {
-        $.get("/api/maintenance",
+    $.get(appUrl("/api/search/"+currentSearchString()), function (instances) {
+        $.get(appUrl("/api/maintenance"),
             function (maintenanceList) {
         		normalizeInstances(instances, maintenanceList);
                 displaySearchInstances(instances);

--- a/resources/public/js/seed-shared.js
+++ b/resources/public/js/seed-shared.js
@@ -8,9 +8,9 @@ function appendSeedDetails(seed, selector) {
 		statusMessage = '<span class="text-info">Active</span>';
 	}
 	row += '<td>' + statusMessage + '</td>';
-	row += '<td><a href="/web/seed-details/' + seed.SeedId + '">' + seed.SeedId + '</a></td>';
-	row += '<td><a href="/web/agent/'+seed.TargetHostname+'">'+seed.TargetHostname+'</a></td>';
-	row += '<td><a href="/web/agent/'+seed.SourceHostname+'">'+seed.SourceHostname+'</a></td>';
+	row += '<td><a href="' + appUrl('/web/seed-details/' + seed.SeedId) + '">' + seed.SeedId + '</a></td>';
+	row += '<td><a href="' + appUrl('/web/agent/'+seed.TargetHostname) + '">'+seed.TargetHostname+'</a></td>';
+	row += '<td><a href="' + appUrl('/web/agent/'+seed.SourceHostname) + '">'+seed.SourceHostname+'</a></td>';
 	row += '<td>' + seed.StartTimestamp + '</td>';
 	row += '<td>' + (seed.IsComplete ? seed.EndTimestamp : '<button class="btn btn-xs btn-danger" data-command="abort-seed" data-seed-source-host="'+seed.SourceHostname+'" data-seed-target-host="'+seed.TargetHostname+'" data-seed-id="' + seed.SeedId + '">Abort</button>') + '</td>';
 	row += '</tr>';
@@ -43,7 +43,7 @@ $("body").on("click", "button[data-command=abort-seed]", function(event) {
 	bootbox.confirm(message, function(confirm) {
 		if (confirm) {
 	    	showLoader();
-	        $.get("/api/agent-abort-seed/"+seedId, function (operationResult) {
+	        $.get(appUrl("/api/agent-abort-seed/"+seedId), function (operationResult) {
 				hideLoader();
 				if (operationResult.Code == "ERROR") {
 					addAlert(operationResult.Message)

--- a/resources/public/js/seed.js
+++ b/resources/public/js/seed.js
@@ -2,7 +2,7 @@
 $(document).ready(function () {
     showLoader();
     
-    $.get("/api/agent-seed-details/"+currentSeedId(), function (seedArray) {
+    $.get(appUrl("/api/agent-seed-details/"+currentSeedId()), function (seedArray) {
 	        showLoader();
 	        seedArray.forEach(function (seed) {
 	    		appendSeedDetails(seed, "[data-agent=seed_details]");
@@ -12,7 +12,7 @@ $(document).ready(function () {
 	    	});
 	    }, "json");
 
-    $.get("/api/agent-seed-states/"+currentSeedId(), function (seedStates) {
+    $.get(appUrl("/api/agent-seed-states/"+currentSeedId()), function (seedStates) {
 	        showLoader();
 	        seedStates.forEach(function (seedState) {
 	        	appendSeedState(seedState);

--- a/resources/public/js/seeds.js
+++ b/resources/public/js/seeds.js
@@ -2,7 +2,7 @@
 $(document).ready(function () {
     showLoader();
     
-    $.get("/api/seeds", function (seeds) {
+    $.get(appUrl("/api/seeds"), function (seeds) {
 	        showLoader();
 	        var hasActive = false;
 	        seeds.forEach(function (seed) {

--- a/resources/public/js/status.js
+++ b/resources/public/js/status.js
@@ -18,7 +18,7 @@ function addStatusActionButton(name, uri) {
 
 $(document).ready(function () {
 	var statusObject = $("#orchestratorStatus .panel-body");
-    $.get("/api/health/", function (health) {
+    $.get(appUrl("/api/health/"), function (health) {
     	statusObject.prepend('<h4>'+health.Message+'</h4>')
     	health.Details.AvailableNodes.forEach(function(node) {
     		var hostname = node.split(";")[0];


### PR DESCRIPTION
Specifically, this lets it work when accessed through the Kubernetes
apiserver proxy, which looks like this to your browser:

http://localhost/api/v1/proxy/.../orchestrator/...

The apiserver proxy rewrites absolute URLs where it can, in HTML and in
HTTP headers, but URLs generated from client-side code (JS) need to be
considerate of the fact that the base URL of the app might not be at the
root of the host.

One solution would be to make all URLs relative, but that gets messy for
apps like Orchestrator that use various levels of path nesting:
  /web/clusters
  /web/cluster/alias/:clusterAlias

Instead, we generate absolute URLs after looking (on the client side) to
see where the user's browser thinks the app is based. This is based on
the assumption that the right-most occurance of "/web/" in the browser
path indicates the base of the Orchestrator web app.