### PR TITLE
Add DetectPromotionRuleQuery option.

### DIFF
--- a/conf/orchestrator-sample.conf.json
+++ b/conf/orchestrator-sample.conf.json
@@ -66,6 +66,7 @@
   "DetectClusterAliasQuery": "SELECT SUBSTRING_INDEX(@@hostname, '.', 1)",
   "DetectClusterDomainQuery": "",
   "DetectInstanceAliasQuery": "",
+  "DetectPromotionRuleQuery": "",
   "DataCenterPattern": "[.]([^.]+)[.][^.]+[.]mydomain[.]com",
   "PhysicalEnvironmentPattern": "[.]([^.]+[.][^.]+)[.]mydomain[.]com",
   "PromotionIgnoreHostnameFilters": [],

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1213,7 +1213,11 @@ func Cli(command string, strict bool, instance string, destination string, owner
 	case registerCliCommand("register-candidate", "Instance, meta", `Indicate that a specific instance is a preferred candidate for master promotion`):
 		{
 			instanceKey = deduceInstanceKeyIfNeeded(instance, instanceKey, true)
-			err := inst.RegisterCandidateInstance(instanceKey, inst.CandidatePromotionRule(*config.RuntimeCLIFlags.PromotionRule))
+			promotionRule, err := inst.ParseCandidatePromotionRule(*config.RuntimeCLIFlags.PromotionRule)
+			if err != nil {
+				log.Fatale(err)
+			}
+			err = inst.RegisterCandidateInstance(instanceKey, promotionRule)
 			if err != nil {
 				log.Fatale(err)
 			}

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -101,6 +101,7 @@ type Configuration struct {
 	DetectClusterAliasQuery                      string            // Optional query (executed on topology instance) that returns the alias of a cluster. Query will only be executed on cluster master (though until the topology's master is resovled it may execute on other/all slaves). If provided, must return one row, one column
 	DetectClusterDomainQuery                     string            // Optional query (executed on topology instance) that returns the VIP/CNAME/Alias/whatever domain name for the master of this cluster. Query will only be executed on cluster master (though until the topology's master is resovled it may execute on other/all slaves). If provided, must return one row, one column
 	DetectInstanceAliasQuery                     string            // Optional query (executed on topology instance) that returns the alias of an instance. If provided, must return one row, one column
+	DetectPromotionRuleQuery                     string            // Optional query (executed on topology instance) that returns the promotion rule of an instance. If provided, must return one row, one column.
 	DataCenterPattern                            string            // Regexp pattern with one group, extracting the datacenter name from the hostname
 	PhysicalEnvironmentPattern                   string            // Regexp pattern with one group, extracting physical environment info from hostname (e.g. combination of datacenter & prod/dev env)
 	DetectDataCenterQuery                        string            // Optional query (executed on topology instance) that returns the data center of an instance. If provided, must return one row, one column. Overrides DataCenterPattern and useful for installments where DC cannot be inferred by hostname
@@ -240,6 +241,7 @@ func newConfiguration() *Configuration {
 		DetectClusterAliasQuery:                      "",
 		DetectClusterDomainQuery:                     "",
 		DetectInstanceAliasQuery:                     "",
+		DetectPromotionRuleQuery:                     "",
 		DataCenterPattern:                            "",
 		PhysicalEnvironmentPattern:                   "",
 		DetectDataCenterQuery:                        "",

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1948,19 +1948,11 @@ func (this *HttpAPI) RegisterCandidate(params martini.Params, r render.Render, r
 		r.JSON(200, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
 	}
-	switch params["promotionRule"] {
-	case "prefer", "neutral", "must_not":
-		{
-			// OK
-		}
-	default:
-		{
-			r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("Invalid promotionRule: %+v", params["promotionRule"])})
-			return
-		}
+	promotionRule, err := inst.ParseCandidatePromotionRule(params["promotionRule"])
+	if err != nil {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: err.Error()})
+		return
 	}
-
-	promotionRule := inst.CandidatePromotionRule(params["promotionRule"])
 
 	err = inst.RegisterCandidateInstance(&instanceKey, promotionRule)
 

--- a/go/inst/instance.go
+++ b/go/inst/instance.go
@@ -38,6 +38,19 @@ const (
 	MustNotPromoteRule                          = "must_not"
 )
 
+// ParseCandidatePromotionRule returns a CandidatePromotionRule by name.
+// It returns an error if there is no known rule by the given name.
+func ParseCandidatePromotionRule(ruleName string) (CandidatePromotionRule, error) {
+	switch ruleName {
+	case "prefer", "neutral", "must_not":
+		return CandidatePromotionRule(ruleName), nil
+	case "must", "prefer_not":
+		return CandidatePromotionRule(""), fmt.Errorf("CandidatePromotionRule: %v not supported yet", ruleName)
+	default:
+		return CandidatePromotionRule(""), fmt.Errorf("Invalid CandidatePromotionRule: %v", ruleName)
+	}
+}
+
 // Instance represents a database instance, including its current configuration & status.
 // It presents important replication configuration and detailed replication status.
 type Instance struct {


### PR DESCRIPTION
This allows us to associate a PromotionRule with an instance as soon as
we discover it.

As discussed in #150.