### PR TITLE
Support Custom Agent Jobs

### DIFF
--- a/go/agent/agent_dao.go
+++ b/go/agent/agent_dao.go
@@ -468,6 +468,16 @@ func AbortSeedCommand(hostname string, seedId int64) (Agent, error) {
 	return executeAgentCommand(hostname, fmt.Sprintf("abort-seed/%d", seedId), nil)
 }
 
+func CustomCommand(hostname string, cmd string) (output string, err error) {
+	onResponse := func(body []byte) {
+		output = string(body)
+		log.Debugf("output: %v", output)
+	}
+
+	_, err = executeAgentCommand(hostname, fmt.Sprintf("custom-commands/%s", cmd), &onResponse)
+	return output, err
+}
+
 // seedCommandCompleted checks an agent to see if it thinks a seed was completed.
 func seedCommandCompleted(hostname string, seedId int64) (Agent, bool, error) {
 	result := false

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/outbrain/golib/log"
 	"github.com/outbrain/golib/util"
+	"github.com/outbrain/orchestrator/go/agent"
 	"github.com/outbrain/orchestrator/go/config"
 	"github.com/outbrain/orchestrator/go/inst"
 	"github.com/outbrain/orchestrator/go/logic"
@@ -1315,7 +1316,16 @@ func Cli(command string, strict bool, instance string, destination string, owner
 			inst.ReadClusters()
 			fmt.Println("Redeployed internal db")
 		}
-		// Help
+	case registerCliCommand("custom-command", "Agent", "Execute a custom command on the agent as defined in the agent conf"):
+		{
+			output, err := agent.CustomCommand(hostnameFlag, pattern)
+			if err != nil {
+				log.Fatale(err)
+			}
+
+			fmt.Printf("%v\n", output)
+		}
+	// Help
 	case "help":
 		{
 			fmt.Fprintf(os.Stderr, availableCommandsUsage())

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1653,6 +1653,26 @@ func (this *HttpAPI) AgentMySQLStart(params martini.Params, r render.Render, req
 	r.JSON(200, output)
 }
 
+func (this *HttpAPI) AgentCustomCommand(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+	if !isAuthorizedForAction(req, user) {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
+		return
+	}
+	if !config.Config.ServeAgentsHttp {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: "Agents not served"})
+		return
+	}
+
+	output, err := agent.CustomCommand(params["host"], params["cmd"])
+
+	if err != nil {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
+		return
+	}
+
+	r.JSON(200, output)
+}
+
 // AgentSeed completely seeds a host with another host's snapshots. This is a complex operation
 // governed by orchestrator and executed by the two agents involved.
 func (this *HttpAPI) AgentSeed(params martini.Params, r render.Render, req *http.Request, user auth.User) {
@@ -2354,6 +2374,7 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	m.Get("/api/agent-seed-details/:seedId", this.AgentSeedDetails)
 	m.Get("/api/agent-seed-states/:seedId", this.AgentSeedStates)
 	m.Get("/api/agent-abort-seed/:seedId", this.AbortSeed)
+	m.Get("/api/agent-custom-command/:host/:command", this.AgentCustomCommand)
 	m.Get("/api/seeds", this.Seeds)
 
 	// Configurable status check endpoint


### PR DESCRIPTION
* Adds basics for supporting calling custom agent jobs. from the CLI or HTTP API a user can call a arbitrary script on the agent as defined in the agent configuration file.