### PR TITLE
fix custom command param name

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1663,7 +1663,7 @@ func (this *HttpAPI) AgentCustomCommand(params martini.Params, r render.Render, 
 		return
 	}
 
-	output, err := agent.CustomCommand(params["host"], params["cmd"])
+	output, err := agent.CustomCommand(params["host"], params["command"])
 
 	if err != nil {
 		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})


### PR DESCRIPTION
Fix parameter name to match how it's defined in go/http/api.go line 2369: `command`