### PR TITLE
global flag that disables recoveries

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -31,6 +31,7 @@ import (
 	"github.com/outbrain/orchestrator/go/inst"
 	"github.com/outbrain/orchestrator/go/logic"
 	"github.com/outbrain/orchestrator/go/process"
+	"github.com/outbrain/orchestrator/go/recovery"
 )
 
 var thisInstanceKey *inst.InstanceKey
@@ -1340,7 +1341,35 @@ func Cli(command string, strict bool, instance string, destination string, owner
 
 			fmt.Printf("%v\n", output)
 		}
-	// Help
+	case registerCliCommand("disable-global-recoveries", "", `Disallow orchestrator from performing recoveries globally`):
+		{
+			if err := recovery.DisableGlobally(); err != nil {
+				fmt.Printf("ERROR: Failed to disable recoveries globally: %v\n", err)
+				// should change exit code ?
+			} else {
+				fmt.Println("OK: Orchestrator recoveries DISABLED globally")
+			}
+		}
+	case registerCliCommand("enable-global-recoveries", "", `Allow orchestrator to perform recoveries globally`):
+		{
+			if err := recovery.EnableGlobally(); err != nil {
+				fmt.Printf("ERROR: Failed to enable recoveries globally: %v\n", err)
+				// should change exit code ?
+			} else {
+				fmt.Println("OK: Orchestrator recoveries ENABLED globally")
+			}
+		}
+	case registerCliCommand("check-global-recoveries", "", `Show the global recovery configuration`):
+		{
+			isDisabled, err := recovery.IsGloballyDisabled()
+			if err != nil {
+				fmt.Printf("ERROR: Failed to determine if recoveries are disabled globally: %v\n", err)
+				// should change exit code ?
+			} else {
+				fmt.Printf("OK: Global recoveries disabled: %v\n", isDisabled)
+			}
+		}
+		// Help
 	case "help":
 		{
 			fmt.Fprintf(os.Stderr, availableCommandsUsage())

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -31,7 +31,6 @@ import (
 	"github.com/outbrain/orchestrator/go/inst"
 	"github.com/outbrain/orchestrator/go/logic"
 	"github.com/outbrain/orchestrator/go/process"
-	"github.com/outbrain/orchestrator/go/recovery"
 )
 
 var thisInstanceKey *inst.InstanceKey
@@ -1343,21 +1342,21 @@ func Cli(command string, strict bool, instance string, destination string, owner
 		}
 	case registerCliCommand("disable-global-recoveries", "", `Disallow orchestrator from performing recoveries globally`):
 		{
-			if err := recovery.DisableGlobally(); err != nil {
+			if err := logic.DisableRecovery(); err != nil {
 				log.Fatalf("ERROR: Failed to disable recoveries globally: %v\n", err)
 			}
 			fmt.Println("OK: Orchestrator recoveries DISABLED globally")
 		}
 	case registerCliCommand("enable-global-recoveries", "", `Allow orchestrator to perform recoveries globally`):
 		{
-			if err := recovery.EnableGlobally(); err != nil {
+			if err := logic.EnableRecovery(); err != nil {
 				log.Fatalf("ERROR: Failed to enable recoveries globally: %v\n", err)
 			}
 			fmt.Println("OK: Orchestrator recoveries ENABLED globally")
 		}
 	case registerCliCommand("check-global-recoveries", "", `Show the global recovery configuration`):
 		{
-			isDisabled, err := recovery.IsGloballyDisabled()
+			isDisabled, err := logic.IsRecoveryDisabled()
 			if err != nil {
 				log.Fatalf("ERROR: Failed to determine if recoveries are disabled globally: %v\n", err)
 			}

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1344,30 +1344,24 @@ func Cli(command string, strict bool, instance string, destination string, owner
 	case registerCliCommand("disable-global-recoveries", "", `Disallow orchestrator from performing recoveries globally`):
 		{
 			if err := recovery.DisableGlobally(); err != nil {
-				fmt.Printf("ERROR: Failed to disable recoveries globally: %v\n", err)
-				// should change exit code ?
-			} else {
-				fmt.Println("OK: Orchestrator recoveries DISABLED globally")
+				log.Fatalf("ERROR: Failed to disable recoveries globally: %v\n", err)
 			}
+			fmt.Println("OK: Orchestrator recoveries DISABLED globally")
 		}
 	case registerCliCommand("enable-global-recoveries", "", `Allow orchestrator to perform recoveries globally`):
 		{
 			if err := recovery.EnableGlobally(); err != nil {
-				fmt.Printf("ERROR: Failed to enable recoveries globally: %v\n", err)
-				// should change exit code ?
-			} else {
-				fmt.Println("OK: Orchestrator recoveries ENABLED globally")
+				log.Fatalf("ERROR: Failed to enable recoveries globally: %v\n", err)
 			}
+			fmt.Println("OK: Orchestrator recoveries ENABLED globally")
 		}
 	case registerCliCommand("check-global-recoveries", "", `Show the global recovery configuration`):
 		{
 			isDisabled, err := recovery.IsGloballyDisabled()
 			if err != nil {
-				fmt.Printf("ERROR: Failed to determine if recoveries are disabled globally: %v\n", err)
-				// should change exit code ?
-			} else {
-				fmt.Printf("OK: Global recoveries disabled: %v\n", isDisabled)
+				log.Fatalf("ERROR: Failed to determine if recoveries are disabled globally: %v\n", err)
 			}
+			fmt.Printf("OK: Global recoveries disabled: %v\n", isDisabled)
 		}
 		// Help
 	case "help":

--- a/go/db/db.go
+++ b/go/db/db.go
@@ -498,6 +498,12 @@ var generateSQLBase = []string{
 		  PRIMARY KEY (deployed_version)
 		) ENGINE=InnoDB DEFAULT CHARSET=ascii
 	`,
+	`
+		CREATE TABLE global_recovery_disable (
+		  disable_recovery tinyint unsigned NOT NULL COMMENT 'Insert 1 to disable recovery globally',
+		  PRIMARY KEY (disable_recovery)
+		) ENGINE=InnoDB DEFAULT CHARSET=ascii COMMENT='checked with: SELECT COUNT(*) FROM global_recovery_disable WHERE disable_recovery=1'
+	`,
 }
 
 // generateSQLPatches contains DDLs for patching schema to the latest version.

--- a/go/db/db.go
+++ b/go/db/db.go
@@ -499,10 +499,10 @@ var generateSQLBase = []string{
 		) ENGINE=InnoDB DEFAULT CHARSET=ascii
 	`,
 	`
-		CREATE TABLE global_recovery_disable (
+		CREATE TABLE IF NOT EXISTS global_recovery_disable (
 		  disable_recovery tinyint unsigned NOT NULL COMMENT 'Insert 1 to disable recovery globally',
 		  PRIMARY KEY (disable_recovery)
-		) ENGINE=InnoDB DEFAULT CHARSET=ascii COMMENT='checked with: SELECT COUNT(*) FROM global_recovery_disable WHERE disable_recovery=1'
+		) ENGINE=InnoDB DEFAULT CHARSET=ascii
 	`,
 }
 

--- a/go/logic/disable_recovery.go
+++ b/go/logic/disable_recovery.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package recovery
+package logic
 
 // This file holds wrappers around routines to check if global
 // recovery is disabled or not.
@@ -35,8 +35,8 @@ import (
 	"github.com/outbrain/orchestrator/go/db"
 )
 
-// IsGloballyDisabled returns true if Recoveries are disabled globally
-func IsGloballyDisabled() (bool, error) {
+// IsRecoveryDisabled returns true if Recoveries are disabled globally
+func IsRecoveryDisabled() (bool, error) {
 	var (
 		disabled bool // default is false!
 		err      error
@@ -55,13 +55,13 @@ func IsGloballyDisabled() (bool, error) {
 		return nil
 	})
 	if err != nil {
-		err = log.Errorf("recovery.IsGloballyDisabled(): %v", err)
+		err = log.Errorf("recovery.IsRecoveryDisabled(): %v", err)
 	}
 	return disabled, err
 }
 
-// DisableGlobally ensures recoveries are disabled globally
-func DisableGlobally() error {
+// DisableRecovery ensures recoveries are disabled globally
+func DisableRecovery() error {
 	_, err := db.ExecOrchestrator(`
 		INSERT IGNORE INTO global_recovery_disable
 			(disable_recovery)
@@ -71,8 +71,8 @@ func DisableGlobally() error {
 	return err
 }
 
-// EnableGlobally ensures recoveries are enabled globally
-func EnableGlobally() error {
+// EnableRecovery ensures recoveries are enabled globally
+func EnableRecovery() error {
 	_, err := db.ExecOrchestrator(`
 		DELETE FROM global_recovery_disable -- deliberately no WHERE clause
 	`,

--- a/go/logic/disable_recovery.go
+++ b/go/logic/disable_recovery.go
@@ -74,7 +74,7 @@ func DisableRecovery() error {
 // EnableRecovery ensures recoveries are enabled globally
 func EnableRecovery() error {
 	_, err := db.ExecOrchestrator(`
-		DELETE FROM global_recovery_disable -- deliberately no WHERE clause
+		DELETE FROM global_recovery_disable
 	`,
 	)
 	return err

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -29,7 +29,7 @@ import (
 	"github.com/outbrain/orchestrator/go/os"
 	"github.com/outbrain/orchestrator/go/process"
 	"github.com/outbrain/orchestrator/go/recovery"
-	"github.com/patrickmn/go-cache"
+	"github.com/pmylund/go-cache"
 	"github.com/rcrowley/go-metrics"
 )
 
@@ -1055,7 +1055,9 @@ func CheckAndRecover(specificInstance *inst.InstanceKey, candidateInstanceKey *i
 				promotedSlaveKey = topologyRecovery.SuccessorKey
 			}
 		} else if recoveryDisabledGlobally {
-			log.Debugf("CheckAndRecover: InstanceKey: %+v, candidateInstanceKey: %+v, skipProcesses: %v: NOT Recovering host (disabled globally)", analysisEntry.AnalyzedInstanceKey, candidateInstanceKey, skipProcesses)
+			log.Infof("CheckAndRecover: InstanceKey: %+v, candidateInstanceKey: %+v, "+
+				"skipProcesses: %v: NOT Recovering host (disabled globally)",
+				analysisEntry.AnalyzedInstanceKey, candidateInstanceKey, skipProcesses)
 		} else {
 			go executeCheckAndRecoverFunction(analysisEntry, candidateInstanceKey, false, skipProcesses)
 		}

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -28,7 +28,8 @@ import (
 	"github.com/outbrain/orchestrator/go/inst"
 	"github.com/outbrain/orchestrator/go/os"
 	"github.com/outbrain/orchestrator/go/process"
-	"github.com/pmylund/go-cache"
+	"github.com/outbrain/orchestrator/go/recovery"
+	"github.com/patrickmn/go-cache"
 	"github.com/rcrowley/go-metrics"
 )
 
@@ -1020,9 +1021,15 @@ func executeCheckAndRecoverFunction(analysisEntry inst.ReplicationAnalysis, cand
 
 // CheckAndRecover is the main entry point for the recovery mechanism
 func CheckAndRecover(specificInstance *inst.InstanceKey, candidateInstanceKey *inst.InstanceKey, skipProcesses bool) (recoveryAttempted bool, promotedSlaveKey *inst.InstanceKey, err error) {
+	// Allow the analysis to run evern if we don't want to recover
 	replicationAnalysis, err := inst.GetReplicationAnalysis("", true, true)
 	if err != nil {
 		return false, nil, log.Errore(err)
+	}
+	// Check for recovery being disabled globally
+	recoveryDisabledGlobally, err := recovery.IsGloballyDisabled()
+	if err != nil {
+		log.Warningf("Unable to determine if recovery is disabled globally: %v", err)
 	}
 	if *config.RuntimeCLIFlags.Noop {
 		log.Debugf("--noop provided; will not execute processes")
@@ -1047,6 +1054,8 @@ func CheckAndRecover(specificInstance *inst.InstanceKey, candidateInstanceKey *i
 			if topologyRecovery != nil {
 				promotedSlaveKey = topologyRecovery.SuccessorKey
 			}
+		} else if recoveryDisabledGlobally {
+			log.Debugf("CheckAndRecover: InstanceKey: %+v, candidateInstanceKey: %+v, skipProcesses: %v: NOT Recovering host (disabled globally)", analysisEntry.AnalyzedInstanceKey, candidateInstanceKey, skipProcesses)
 		} else {
 			go executeCheckAndRecoverFunction(analysisEntry, candidateInstanceKey, false, skipProcesses)
 		}

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -28,7 +28,6 @@ import (
 	"github.com/outbrain/orchestrator/go/inst"
 	"github.com/outbrain/orchestrator/go/os"
 	"github.com/outbrain/orchestrator/go/process"
-	"github.com/outbrain/orchestrator/go/recovery"
 	"github.com/pmylund/go-cache"
 	"github.com/rcrowley/go-metrics"
 )
@@ -1027,7 +1026,7 @@ func CheckAndRecover(specificInstance *inst.InstanceKey, candidateInstanceKey *i
 		return false, nil, log.Errore(err)
 	}
 	// Check for recovery being disabled globally
-	recoveryDisabledGlobally, err := recovery.IsGloballyDisabled()
+	recoveryDisabledGlobally, err := IsRecoveryDisabled()
 	if err != nil {
 		log.Warningf("Unable to determine if recovery is disabled globally: %v", err)
 	}

--- a/go/recovery/recovery.go
+++ b/go/recovery/recovery.go
@@ -1,0 +1,84 @@
+/*
+   Copyright 2016 Simon J Mudd <sjmudd@pobox.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package recovery
+
+// This file holds wrappers around routines to check if global
+// recovery is disabled or not.
+//
+// This is determined by looking in the table
+// orchestrator.global_recovery_disable for a value 1.  Note: for
+// recoveries to actually happen this must be configured explicitly
+// in orchestrator.conf.json. This setting is an emergency brake
+// to quickly be able to prevent recoveries happening in some large
+// outage type situation.  Maybe this value should be cached etc
+// but we won't be doing that many recoveries at once so the load
+// on this table is expected to be very low. It should be fine to
+// go to the database each time.
+
+import (
+	"fmt"
+
+	"github.com/outbrain/golib/sqlutils"
+
+	"github.com/outbrain/orchestrator/go/db"
+)
+
+// IsGloballyDisabled returns true if Recoveries are disabled globally
+func IsGloballyDisabled() (bool, error) {
+	var (
+		disabled bool // default is false!
+		err      error
+	)
+	query := `
+		SELECT
+			COUNT(*) as mycount
+		FROM
+			global_recovery_disable
+		WHERE
+			disable_recovery=?
+		`
+	err = db.QueryOrchestrator(query, sqlutils.Args(1), func(m sqlutils.RowMap) error {
+		mycount := m.GetInt("mycount")
+		disabled = (mycount == 1)
+		return nil
+	})
+	if err != nil {
+		err = fmt.Errorf("recovery.IsGloballyDisabled(): %v", err)
+	}
+	return disabled, err
+}
+
+// DisableGlobally ensures recoveries are disabled globally
+func DisableGlobally() error {
+	_, err := db.ExecOrchestrator(`
+		INSERT IGNORE INTO global_recovery_disable
+			(disable_recovery)
+		VALUES  (1)
+	`,
+	)
+	return err
+}
+
+// EnableGlobally ensures recoveries are enabled globally
+func EnableGlobally() error {
+	// Could be TRUNCATE TABLE global_recovery_disable but we only expect to have 0 or 1 rows so not worth it?
+	_, err := db.ExecOrchestrator(`
+		DELETE FROM global_recovery_disable -- deliberately no WHERE clause
+	`,
+	)
+	return err
+}

--- a/go/recovery/recovery.go
+++ b/go/recovery/recovery.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016 Simon J Mudd <sjmudd@pobox.com>
+   Copyright 2015 Shlomi Noach, courtesy Booking.com
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -30,10 +30,8 @@ package recovery
 // go to the database each time.
 
 import (
-	"fmt"
-
+	"github.com/outbrain/golib/log"
 	"github.com/outbrain/golib/sqlutils"
-
 	"github.com/outbrain/orchestrator/go/db"
 )
 
@@ -53,11 +51,11 @@ func IsGloballyDisabled() (bool, error) {
 		`
 	err = db.QueryOrchestrator(query, sqlutils.Args(1), func(m sqlutils.RowMap) error {
 		mycount := m.GetInt("mycount")
-		disabled = (mycount == 1)
+		disabled = (mycount > 0)
 		return nil
 	})
 	if err != nil {
-		err = fmt.Errorf("recovery.IsGloballyDisabled(): %v", err)
+		err = log.Errorf("recovery.IsGloballyDisabled(): %v", err)
 	}
 	return disabled, err
 }
@@ -75,7 +73,6 @@ func DisableGlobally() error {
 
 // EnableGlobally ensures recoveries are enabled globally
 func EnableGlobally() error {
-	// Could be TRUNCATE TABLE global_recovery_disable but we only expect to have 0 or 1 rows so not worth it?
 	_, err := db.ExecOrchestrator(`
 		DELETE FROM global_recovery_disable -- deliberately no WHERE clause
 	`,


### PR DESCRIPTION
Orchestrator does it's best to fix topologies which is great but may not be desired during major outages. We added a DB flag and three command line options to disable/enable/check if recoveries are disabled.