### PR TITLE
fix: all discovery workers exit on re-elections

### DIFF
--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -96,7 +96,7 @@ func handleDiscoveryRequests() {
 				if atomic.LoadInt64(&isElectedNode) != 1 {
 					log.Debugf("Node apparently demoted. Skipping discovery of %+v. "+
 						"Remaining queue size: %+v", instanceKey, discoveryQueue.Len())
-					return
+					continue
 				}
 				discoverInstance(instanceKey)
 			}


### PR DESCRIPTION
When a node becomes inactive and then active again it does not do discoveries anymore as there're no discovery workers. I overlooked this in https://github.com/outbrain/orchestrator/pull/237. Discovery workers must not exit because the pool is created only once during initialisation.