### PR TITLE
tell who is active on an inactive machine

### DIFF
--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -221,7 +221,12 @@ func ContinuousDiscovery() {
 						go process.RegisterNode("", "", false)
 					}
 				} else {
-					log.Debugf("Not elected as active node; polling")
+					hostname, _, _, err := process.ElectedNode()
+					if err == nil {
+						log.Debugf("Not elected as active node; active node: %v; polling", hostname)
+					} else {
+						log.Debugf("Not elected as active node; active node: Unable to determine: %v; polling", err)
+					}
 				}
 			}()
 		case <-instancePollTick:


### PR DESCRIPTION
It's handy to see active machine hostname in logs.