### PR TITLE
Allow reset-master-gtid-remove-own-uuid to work even if master_auto_p…

### DIFF
--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1190,7 +1190,7 @@ func ResetMasterGTIDOperation(instanceKey *InstanceKey, removeSelfUUID bool, uui
 	if err != nil {
 		return instance, err
 	}
-	if !instance.UsingOracleGTID {
+	if !instance.SupportsOracleGTID {
 		return instance, log.Errorf("reset-master-gtid requested for %+v but it is not using oracle-gtid", *instanceKey)
 	}
 	if len(instance.SlaveHosts) > 0 {


### PR DESCRIPTION
…osition = 0 (as long as gtid_mode = ON)

I have some MySQL servers with gtid_mode = ON but auto_position = 0. This enables this command to clean up such errant GTIDs introduced on the downstream slave.