### PR TITLE
fix non-ascii encoding for last_sql_error

### DIFF
--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -263,8 +264,8 @@ func ReadTopologyInstance(instanceKey *InstanceKey) (*Instance, error) {
 		instance.RelaylogCoordinates.LogFile = m.GetString("Relay_Log_File")
 		instance.RelaylogCoordinates.LogPos = m.GetInt64("Relay_Log_Pos")
 		instance.RelaylogCoordinates.Type = RelayLog
-		instance.LastSQLError = m.GetString("Last_SQL_Error")
-		instance.LastIOError = m.GetString("Last_IO_Error")
+		instance.LastSQLError = strconv.QuoteToASCII(m.GetString("Last_SQL_Error"))
+		instance.LastIOError = strconv.QuoteToASCII(m.GetString("Last_IO_Error"))
 		instance.SQLDelay = m.GetUintD("SQL_Delay", 0)
 		instance.UsingOracleGTID = (m.GetIntD("Auto_Position", 0) == 1)
 		instance.ExecutedGtidSet = m.GetStringD("Executed_Gtid_Set", "")


### PR DESCRIPTION
We're seeing this errors:
     ERROR Error 1366: Incorrect string value: '\xE1\xBB\xBC\x05 \xDE...' for column 'last_sql_error'

on instance writes to backend DB. Apparently,
last_sql_error is not ascii while it must be
(see database_instance table definition).

It's the first time we see the error: probably
not a good reason to change DB schema yet,
so quoting a string.