### PR TITLE
Only one discovery per host

### DIFF
--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -96,9 +96,15 @@ func handleDiscoveryRequests() {
 				if atomic.LoadInt64(&isElectedNode) != 1 {
 					log.Debugf("Node apparently demoted. Skipping discovery of %+v. "+
 						"Remaining queue size: %+v", instanceKey, discoveryQueue.Len())
+
+					discoveryQueue.Release(instanceKey)
+
 					continue
 				}
+
 				discoverInstance(instanceKey)
+
+				discoveryQueue.Release(instanceKey)
 			}
 		}()
 	}
@@ -113,8 +119,6 @@ func discoverInstance(instanceKey inst.InstanceKey) {
 		if discoveryTime > time.Duration(config.Config.InstancePollSeconds)*time.Second {
 			log.Warningf("discoverInstance for key %v took %.4fs", instanceKey, discoveryTime.Seconds())
 		}
-
-		discoveryQueue.Release(instanceKey)
 	}()
 
 	instanceKey.Formalize()


### PR DESCRIPTION
Even with all timeouts on a mysql driver level a failing instance may take a while to be processed. When this happens, discovery queues tend to pile up on that instance. This branch makes sure that only one discovery worker is processing an instance at a time.
