### PR TITLE
add topology discovery db pool

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -64,7 +64,8 @@ type Configuration struct {
 	MySQLOrchestratorUseMutualTLS                bool     // Turn on TLS authentication with the Orchestrator MySQL instance
 	MySQLConnectTimeoutSeconds                   int      // Number of seconds before connection is aborted (driver-side)
 	MySQLOrchestratorReadTimeoutSeconds          int      // Number of seconds before backend mysql read operation is aborted (driver-side)
-	MySQLTopologyReadTimeoutSeconds              int      // Number of seconds before topology mysql read operation is aborted (driver-side)
+	MySQLDiscoveryReadTimeoutSeconds             int      // Number of seconds before topology mysql read operation is aborted (driver-side). Used for discovery queries.
+	MySQLTopologyReadTimeoutSeconds              int      // Number of seconds before topology mysql read operation is aborted (driver-side). Used for all but discovery queries.
 	DefaultInstancePort                          int      // In case port was not specified on command line
 	SlaveLagQuery                                string   // custom query to check on slave lg (e.g. heartbeat table)
 	SlaveStartPostWaitMilliseconds               int      // Time to wait after START SLAVE before re-readong instance (give slave chance to connect to master)
@@ -218,7 +219,8 @@ func newConfiguration() *Configuration {
 		MySQLOrchestratorUseMutualTLS:                false,
 		MySQLConnectTimeoutSeconds:                   2,
 		MySQLOrchestratorReadTimeoutSeconds:          30,
-		MySQLTopologyReadTimeoutSeconds:              10,
+		MySQLDiscoveryReadTimeoutSeconds:             10,
+		MySQLTopologyReadTimeoutSeconds:              600,
 		DefaultInstancePort:                          3306,
 		InstancePollSeconds:                          5,
 		ReadLongRunningQueries:                       true,

--- a/go/db/db.go
+++ b/go/db/db.go
@@ -863,14 +863,25 @@ var topologyTLSConfigured bool = false
 // Track if a TLS has already been configured for Orchestrator
 var orchestratorTLSConfigured bool = false
 
-// OpenTopology returns a DB instance to access a topology instance
+// OpenDiscovery returns a DB instance to access a topology instance.
+// It has lower read timeout than OpenTopology and is intended to
+// be used with low-latency discovery queries.
+func OpenDiscovery(host string, port int) (*sql.DB, error) {
+	return openTopology(host, port, config.Config.MySQLDiscoveryReadTimeoutSeconds)
+}
+
+// OpenTopology returns a DB instance to access a topology instance.
 func OpenTopology(host string, port int) (*sql.DB, error) {
+	return openTopology(host, port, config.Config.MySQLTopologyReadTimeoutSeconds)
+}
+
+func openTopology(host string, port int, readTimeout int) (*sql.DB, error) {
 	mysql_uri := fmt.Sprintf("%s:%s@tcp(%s:%d)/?timeout=%ds&readTimeout=%ds",
 		config.Config.MySQLTopologyUser,
 		config.Config.MySQLTopologyPassword,
 		host, port,
 		config.Config.MySQLConnectTimeoutSeconds,
-		config.Config.MySQLTopologyReadTimeoutSeconds,
+		readTimeout,
 	)
 	if config.Config.MySQLTopologyUseMutualTLS {
 		mysql_uri, _ = SetupMySQLTopologyTLS(mysql_uri)

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -105,7 +105,7 @@ func ReadTopologyInstance(instanceKey *InstanceKey) (*Instance, error) {
 		return instance, fmt.Errorf("ReadTopologyInstance will not act on invalid instance key: %+v", *instanceKey)
 	}
 
-	db, err := db.OpenTopology(instanceKey.Hostname, instanceKey.Port)
+	db, err := db.OpenDiscovery(instanceKey.Hostname, instanceKey.Port)
 	if err != nil {
 		goto Cleanup
 	}


### PR DESCRIPTION
And use it for discovery operations.

Some of Orchestrator's 'action' queries on topology
may take long to finish (i.e. binlog manipulations,
restarting slaves, etc). At the same time, we
would like to have low timeouts when doing instance
discoveries in order to detect failing/slow
responding hosts quickly.
