### PR TITLE
Pseudo gtid match 5 7 under 5 6

### DIFF
--- a/go/inst/instance_binlog_dao.go
+++ b/go/inst/instance_binlog_dao.go
@@ -606,7 +606,6 @@ func GetNextBinlogCoordinatesToMatch(
 		}
 		{
 			// Extract next binlog/relaylog entry from other (intended master):
-			// START HACKING
 			// - this must have binlogs. We may need to filter anonymous events if we were processing
 			//   a relay log on instance and the instance's master runs 5.6
 			var event *BinlogEvent
@@ -621,7 +620,6 @@ func GetNextBinlogCoordinatesToMatch(
 					done = true
 				}
 			}
-			// END HACKING
 
 			if event == nil {
 				// end of binary logs for otherInstance: this is unexpected and means instance is more advanced

--- a/go/inst/instance_binlog_dao.go
+++ b/go/inst/instance_binlog_dao.go
@@ -411,49 +411,76 @@ func getNextBinlogEventsChunk(instance *Instance, startingCoordinates BinlogCoor
 	return events, err
 }
 
-// GetNextBinlogCoordinatesToMatch is given a twin-coordinates couple for a would-be slave (instanceKey) and another
-// instance (otherKey).
+// rpad formats the binlog coordinates to a given size. If the size
+// increases this value is modified so it can be reused later. This
+// is to ensure consistent formatting in debug output.
+func rpad(coordinates BinlogCoordinates, length *int) string {
+	s := fmt.Sprintf("%+v", coordinates)
+	if len(s) > *length {
+		*length = len(s)
+	}
+
+	if len(s) >= *length {
+		return s
+	}
+	return fmt.Sprintf("%s%s", s, strings.Repeat(" ", *length-len(s)))
+}
+
+// used by GetNextBinlogCoordinatesToMatch to format debug information appropriately
+// format the event information in debug output
+func formatEventCleanly(event BinlogEvent, length *int) string {
+	return fmt.Sprintf("%+v %+v; %+v", rpad(event.Coordinates, length), event.EventType, strings.Split(strings.TrimSpace(event.Info), "\n")[0])
+}
+
+// GetNextBinlogCoordinatesToMatch is given a twin-coordinates couple for a would-be slave (instance) and another
+// instance (other).
 // This is part of the match-below process, and is the heart of the operation: matching the binlog events starting
 // the twin-coordinates (where both share the same Pseudo-GTID) until "instance" runs out of entries, hopefully
 // before "other" runs out.
 // If "other" runs out that means "instance" is more advanced in replication than "other", in which case we can't
 // turn it into a slave of "other".
-// Otherwise "instance" will point to the *next* binlog entry in "other"
-func GetNextBinlogCoordinatesToMatch(instance *Instance, instanceCoordinates BinlogCoordinates, recordedInstanceRelayLogCoordinates BinlogCoordinates, maxBinlogCoordinates *BinlogCoordinates,
-	other *Instance, otherCoordinates BinlogCoordinates) (*BinlogCoordinates, int, error) {
+// Otherwise "instance" will point to the *next* binlog entry in "other".
+func GetNextBinlogCoordinatesToMatch(
+	instance *Instance,
+	instanceCoordinates BinlogCoordinates,
+	recordedInstanceRelayLogCoordinates BinlogCoordinates,
+	maxBinlogCoordinates *BinlogCoordinates,
+	other *Instance,
+	otherCoordinates BinlogCoordinates) (*BinlogCoordinates, int, error) {
 
+	// create instanceCursor for scanning instance binlog events
 	fetchNextEvents := func(binlogCoordinates BinlogCoordinates) ([]BinlogEvent, error) {
 		return getNextBinlogEventsChunk(instance, binlogCoordinates, 0)
 	}
 	instanceCursor := NewBinlogEventCursor(instanceCoordinates, fetchNextEvents)
 
+	// create otherCursor for scanning other binlog events
 	fetchOtherNextEvents := func(binlogCoordinates BinlogCoordinates) ([]BinlogEvent, error) {
 		return getNextBinlogEventsChunk(other, binlogCoordinates, 0)
 	}
 	otherCursor := NewBinlogEventCursor(otherCoordinates, fetchOtherNextEvents)
 
-	var beautifyCoordinatesLength int = 0
-	rpad := func(s string, length int) string {
-		if len(s) >= length {
-			return s
-		}
-		return fmt.Sprintf("%s%s", s, strings.Repeat(" ", length-len(s)))
-	}
+	const noMatchedEvents int = 0 // to make return statements' intent clearer
+	var (
+		beautifyCoordinatesLength    int = 0
+		countMatchedEvents           int = 0
+		lastConsumedEventCoordinates BinlogCoordinates
+	)
 
-	var lastConsumedEventCoordinates BinlogCoordinates
-	var countMatchedEvents int = 0
 	for {
 		// Exhaust binlogs/relaylogs on instance. While iterating them, also iterate the otherInstance binlogs.
 		// We expect entries on both to match, sequentially, until instance's binlogs/relaylogs are exhausted.
-		var instanceEventInfo string
-		var otherEventInfo string
-		var eventCoordinates BinlogCoordinates
-		var otherEventCoordinates BinlogCoordinates
+		var (
+			// the whole event to make things simpler
+			instanceEvent BinlogEvent
+			otherEvent    BinlogEvent
+		)
+
 		{
 			// Extract next binlog/relaylog entry from instance:
 			event, err := instanceCursor.nextRealEvent(0)
 			if err != nil {
-				return nil, 0, log.Errore(err)
+				return nil, noMatchedEvents, log.Errore(err)
 			}
 			if event != nil {
 				lastConsumedEventCoordinates = event.Coordinates
@@ -463,16 +490,21 @@ func GetNextBinlogCoordinatesToMatch(instance *Instance, instanceCoordinates Bin
 			case BinaryLog:
 				if event == nil {
 					// end of binary logs for instance:
-					targetMatchCoordinates, err := otherCursor.getNextCoordinates()
+					otherNextCoordinates, err := otherCursor.getNextCoordinates()
 					if err != nil {
-						return nil, 0, log.Errore(err)
+						return nil, noMatchedEvents, log.Errore(err)
 					}
-					nextCoordinates, _ := instanceCursor.getNextCoordinates()
-					if nextCoordinates.SmallerThan(&instance.SelfBinlogCoordinates) {
-						return nil, 0, log.Errorf("Unexpected problem: instance binlog iteration ended before self coordinates. Ended with: %+v, self coordinates: %+v", nextCoordinates, instance.SelfBinlogCoordinates)
+					instanceNextCoordinates, err := instanceCursor.getNextCoordinates()
+					if err != nil {
+						return nil, noMatchedEvents, log.Errore(err)
 					}
-					log.Debugf("Reached end of binary logs for instance, at %+v. Other coordinates: %+v", nextCoordinates, targetMatchCoordinates)
-					return &targetMatchCoordinates, countMatchedEvents, nil
+					// sanity check
+					if instanceNextCoordinates.SmallerThan(&instance.SelfBinlogCoordinates) {
+						return nil, noMatchedEvents, log.Errorf("Unexpected problem: instance binlog iteration ended before self coordinates. Ended with: %+v, self coordinates: %+v", instanceNextCoordinates, instance.SelfBinlogCoordinates)
+					}
+					// Possible good exit point.
+					log.Debugf("Reached end of binary logs for instance, at %+v. Other coordinates: %+v", instanceNextCoordinates, otherNextCoordinates)
+					return &otherNextCoordinates, countMatchedEvents, nil
 				}
 			case RelayLog:
 				// Argghhhh! SHOW RELAY LOG EVENTS IN '...' statement returns CRAPPY values for End_log_pos:
@@ -494,61 +526,54 @@ func GetNextBinlogCoordinatesToMatch(instance *Instance, instanceCoordinates Bin
 					endOfScan = true
 					log.Debugf("Reached slave relay log coordinates at %+v", recordedInstanceRelayLogCoordinates)
 				} else if recordedInstanceRelayLogCoordinates.SmallerThan(&event.Coordinates) {
-					return nil, 0, log.Errorf("Unexpected problem: relay log scan passed relay log position without hitting it. Ended with: %+v, relay log position: %+v", event.Coordinates, recordedInstanceRelayLogCoordinates)
+					return nil, noMatchedEvents, log.Errorf("Unexpected problem: relay log scan passed relay log position without hitting it. Ended with: %+v, relay log position: %+v", event.Coordinates, recordedInstanceRelayLogCoordinates)
 				}
 				if endOfScan {
 					// end of binary logs for instance:
-					targetMatchCoordinates, err := otherCursor.getNextCoordinates()
+					otherNextCoordinates, err := otherCursor.getNextCoordinates()
 					if err != nil {
-						log.Debugf("Cannot otherCursor.getNextCoordinates(). otherCoordinates=%+v, cached events in cursor: %d; index=%d", otherCoordinates, len(otherCursor.cachedEvents), otherCursor.currentEventIndex)
-						return nil, 0, log.Errore(err)
+						log.Debugf("otherCursor.getNextCoordinates() failed. otherCoordinates=%+v, cached events in cursor: %d; index=%d", otherCoordinates, len(otherCursor.cachedEvents), otherCursor.currentEventIndex)
+						return nil, noMatchedEvents, log.Errore(err)
 					}
+					// Possible good exit point.
 					// No further sanity checks (read the above lengthy explanation)
-					log.Debugf("Reached limit of relay logs for instance, just after %+v. Other coordinates: %+v", lastConsumedEventCoordinates, targetMatchCoordinates)
-					return &targetMatchCoordinates, countMatchedEvents, nil
+					log.Debugf("Reached limit of relay logs for instance, just after %+v. Other coordinates: %+v", lastConsumedEventCoordinates, otherNextCoordinates)
+					return &otherNextCoordinates, countMatchedEvents, nil
 				}
 			}
 
-			instanceEventInfo = event.Info
-			eventCoordinates = event.Coordinates
-			coordinatesStr := fmt.Sprintf("%+v", event.Coordinates)
-			if len(coordinatesStr) > beautifyCoordinatesLength {
-				beautifyCoordinatesLength = len(coordinatesStr)
-			}
-			log.Debugf("> %+v %+v; %+v", rpad(coordinatesStr, beautifyCoordinatesLength), event.EventType, strings.Split(strings.TrimSpace(instanceEventInfo), "\n")[0])
+			instanceEvent = *event // make a physical copy
+			log.Debugf("> %s", formatEventCleanly(instanceEvent, &beautifyCoordinatesLength))
 		}
 		{
 			// Extract next binlog/relaylog entry from otherInstance (intended master):
 			event, err := otherCursor.nextRealEvent(0)
 			if err != nil {
-				return nil, 0, log.Errore(err)
+				return nil, noMatchedEvents, log.Errore(err)
 			}
 			if event == nil {
 				// end of binary logs for otherInstance: this is unexpected and means instance is more advanced
 				// than otherInstance
-				return nil, 0, log.Errorf("Unexpected end of binary logs for assumed master (%+v). This means the instance which attempted to be a slave (%+v) was more advanced. Try the other way round", other.Key, instance.Key)
+				return nil, noMatchedEvents, log.Errorf("Unexpected end of binary logs for assumed master (%+v). This means the instance which attempted to be a slave (%+v) was more advanced. Try the other way round", other.Key, instance.Key)
 			}
-			otherEventInfo = event.Info
-			otherEventCoordinates = event.Coordinates
-			coordinatesStr := fmt.Sprintf("%+v", event.Coordinates)
-			if len(coordinatesStr) > beautifyCoordinatesLength {
-				beautifyCoordinatesLength = len(coordinatesStr)
-			}
-			log.Debugf("< %+v %+v; %+v", rpad(coordinatesStr, beautifyCoordinatesLength), event.EventType, strings.Split(strings.TrimSpace(otherEventInfo), "\n")[0])
+
+			otherEvent = *event // make a physical copy
+			log.Debugf("< %s", formatEventCleanly(otherEvent, &beautifyCoordinatesLength))
 		}
 		// Verify things are sane (the two extracted entries are identical):
 		// (not strictly required by the algorithm but adds such a lovely self-sanity-testing essence)
-		if instanceEventInfo != otherEventInfo {
-			return nil, 0, log.Errorf("Mismatching entries, aborting: %+v <-> %+v", instanceEventInfo, otherEventInfo)
+		if instanceEvent.Info != otherEvent.Info {
+			return nil, noMatchedEvents, log.Errorf("Mismatching entries, aborting: %+v <-> %+v", instanceEvent.Info, otherEvent.Info)
 		}
 		countMatchedEvents++
 		if maxBinlogCoordinates != nil {
+			// Possible good exit point.
 			// Not searching till end of binary logs/relay log exec pos. Instead, we're stopping at an instructed position.
-			if eventCoordinates.Equals(maxBinlogCoordinates) {
+			if instanceEvent.Coordinates.Equals(maxBinlogCoordinates) {
 				log.Debugf("maxBinlogCoordinates specified as %+v and reached. Stopping", *maxBinlogCoordinates)
-				return &otherEventCoordinates, countMatchedEvents, nil
-			} else if maxBinlogCoordinates.SmallerThan(&eventCoordinates) {
-				return nil, 0, log.Errorf("maxBinlogCoordinates (%+v) exceeded but not met", *maxBinlogCoordinates)
+				return &otherEvent.Coordinates, countMatchedEvents, nil
+			} else if maxBinlogCoordinates.SmallerThan(&instanceEvent.Coordinates) {
+				return nil, noMatchedEvents, log.Errorf("maxBinlogCoordinates (%+v) exceeded but not met", *maxBinlogCoordinates)
 			}
 		}
 	}


### PR DESCRIPTION
Fix an issue when moving a 5.7 slave which replicates under a 5.7 intermediate master back under a 5.6 master in pseudo-GTID mode.  Sounds complicated but does happen. 5.7 binlogs contain extra events not on the 5.6 master so the matching process will fail.

This PR consists of two patches:
(1) a "cosmetic" cleanup to GetNextBinlogCoordinatesToMatch to using consistent naming which makes following the logic somewhat easier (for me at least). No functionality changes here but the logic is involved so making it easier to follow should help future readers.
(2) The patch that modifies the behaviour when scanning the 5.7 slave's bin or relay logs under the conditions described.

Hopefully the logic and descriptions make this clear enough to follow.