### PR TITLE
Add two new bulk export functions to allow bulk promotion rule changes

### DIFF
--- a/doc/Orchestrator-Manual.md
+++ b/doc/Orchestrator-Manual.md
@@ -1302,6 +1302,9 @@ _Orchestrator_ picks best course of action.
 * `/api/deregister-hostname-unresolve/:host/:port`:  unregister the given mapping for the given host
 * `/api/register-hostname-unresolve/:host/:port/:virtualname`: register the host which should be used when unresolving the given virtual name
 
+The following bulk retrieval rules are intended for allowing the information inside orchestrator to be used by external systems.
+* `/api/bulk-instance`: provide a json list of instances in the form of Hostname Port
+* `/api/bulk-promotion-rules`: provide a json list of instance promotion rules in the form of Hostname Port PromotionRule
 
 #### Instance JSON breakdown
 

--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/user"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/outbrain/golib/log"
@@ -41,6 +42,12 @@ type CliCommand struct {
 	Section     string
 	Description string
 }
+
+type stringSlice []string
+
+func (a stringSlice) Len() int           { return len(a) }
+func (a stringSlice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a stringSlice) Less(i, j int) bool { return a[i] < a[j] }
 
 func registerCliCommand(command string, section string, description string) string {
 	knownCommands = append(knownCommands, CliCommand{Command: command, Section: section, Description: description})
@@ -1361,6 +1368,34 @@ func Cli(command string, strict bool, instance string, destination string, owner
 				log.Fatalf("ERROR: Failed to determine if recoveries are disabled globally: %v\n", err)
 			}
 			fmt.Printf("OK: Global recoveries disabled: %v\n", isDisabled)
+		}
+	case registerCliCommand("bulk-instances", "", `Return a list of sorted instance names known to orchestrator`):
+		{
+			instances, err := inst.BulkReadInstance()
+			if err != nil {
+				log.Fatalf("Error: Failed to retrieve instances: %v\n", err)
+				return
+			}
+			var asciiInstances stringSlice
+			for _, v := range instances {
+				asciiInstances = append(asciiInstances, v.String())
+			}
+			sort.Sort(asciiInstances)
+			fmt.Printf("%s\n", strings.Join(asciiInstances, "\n"))
+		}
+	case registerCliCommand("bulk-promotion-rules", "", `Return a list of promotion rules known to orchestrator`):
+		{
+			promotionRules, err := inst.BulkReadCandidateDatabaseInstance()
+			if err != nil {
+				log.Fatalf("Error: Failed to retrieve promotion rules: %v\n", err)
+			}
+			var asciiPromotionRules stringSlice
+			for _, v := range promotionRules {
+				asciiPromotionRules = append(asciiPromotionRules, v.String())
+			}
+			sort.Sort(asciiPromotionRules)
+
+			fmt.Printf("%s\n", strings.Join(asciiPromotionRules, "\n"))
 		}
 		// Help
 	case "help":

--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1821,6 +1821,38 @@ func (this *HttpAPI) AgentSeedStates(params martini.Params, r render.Render, req
 	r.JSON(200, output)
 }
 
+// BulkPromotionRules returns a list of the known promotion rules for each instance
+func (this *HttpAPI) BulkPromotionRules(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+	if !isAuthorizedForAction(req, user) {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
+		return
+	}
+
+	promotionRules, err := inst.BulkReadCandidateDatabaseInstance()
+	if err != nil {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
+		return
+	}
+
+	r.JSON(200, promotionRules)
+}
+
+// BulkInstances returns a list of all known instances
+func (this *HttpAPI) BulkInstances(params martini.Params, r render.Render, req *http.Request, user auth.User) {
+	if !isAuthorizedForAction(req, user) {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: "Unauthorized"})
+		return
+	}
+
+	instances, err := inst.BulkReadInstance()
+	if err != nil {
+		r.JSON(200, &APIResponse{Code: ERROR, Message: fmt.Sprintf("%+v", err)})
+		return
+	}
+
+	r.JSON(200, instances)
+}
+
 // Seeds retruns all recent seeds
 func (this *HttpAPI) Seeds(params martini.Params, r render.Render, req *http.Request, user auth.User) {
 	if !isAuthorizedForAction(req, user) {
@@ -2392,6 +2424,10 @@ func (this *HttpAPI) RegisterRequests(m *martini.ClassicMartini) {
 	m.Get(this.URLPrefix+"/api/reset-hostname-resolve-cache", this.ResetHostnameResolveCache)
 	m.Get(this.URLPrefix+"/api/deregister-hostname-unresolve/:host/:port", this.DeregisterHostnameUnresolve)
 	m.Get(this.URLPrefix+"/api/register-hostname-unresolve/:host/:port/:virtualname", this.RegisterHostnameUnresolve)
+
+	// Bulk access to information
+	m.Get("/api/bulk-instances", this.BulkInstances)
+	m.Get("/api/bulk-promotion-rules", this.BulkPromotionRules)
 
 	// Agents
 	m.Get(this.URLPrefix+"/api/agents", this.Agents)

--- a/go/inst/candidate_database_instance.go
+++ b/go/inst/candidate_database_instance.go
@@ -1,0 +1,71 @@
+/*
+   Copyright 2016 Simon J Mudd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package inst
+
+import (
+	"github.com/outbrain/golib/sqlutils"
+
+	"github.com/outbrain/orchestrator/go/config"
+	"github.com/outbrain/orchestrator/go/db"
+)
+
+// CandidateDatabaseInstance contains information about explicit promotion rules for an instance
+type CandidateDatabaseInstance struct {
+	Hostname      string
+	Port          int
+	PromotionRule CandidatePromotionRule
+}
+
+// BulkReadCandidateDatabaseInstance returns a slice of
+// CandidateDatabaseInstance converted to JSON.
+/*
+root@myorchestrator [orchestrator]> select * from candidate_database_instance;
++-------------------+------+---------------------+----------+----------------+
+| hostname          | port | last_suggested      | priority | promotion_rule |
++-------------------+------+---------------------+----------+----------------+
+| host1.example.com | 3306 | 2016-11-22 17:41:06 |        1 | prefer         |
+| host2.example.com | 3306 | 2016-11-22 17:40:24 |        1 | prefer         |
++-------------------+------+---------------------+----------+----------------+
+2 rows in set (0.00 sec)
+*/
+func BulkReadCandidateDatabaseInstance() ([]CandidateDatabaseInstance, error) {
+	if config.Config.DatabaselessMode__experimental {
+		return nil, nil // no data to return if not using a database
+	}
+
+	var candidateDatabaseInstances []CandidateDatabaseInstance
+
+	// Read all promotion rules from the table
+	query := `
+SELECT	hostname,
+	port,
+	promotion_rule -- no munging done here yet
+FROM	candidate_database_instance
+`
+	err := db.QueryOrchestrator(query, nil, func(m sqlutils.RowMap) error {
+		cdi := CandidateDatabaseInstance{
+			Hostname:      m.GetString("hostname"),
+			Port:          m.GetInt("port"),
+			PromotionRule: CandidatePromotionRule(m.GetString("promotion_rule")),
+		}
+		// add to end of candidateDatabaseInstances
+		candidateDatabaseInstances = append(candidateDatabaseInstances, cdi)
+
+		return nil
+	})
+	return candidateDatabaseInstances, err
+}

--- a/go/inst/candidate_database_instance.go
+++ b/go/inst/candidate_database_instance.go
@@ -17,6 +17,8 @@
 package inst
 
 import (
+	"fmt"
+
 	"github.com/outbrain/golib/sqlutils"
 
 	"github.com/outbrain/orchestrator/go/config"
@@ -28,6 +30,11 @@ type CandidateDatabaseInstance struct {
 	Hostname      string
 	Port          int
 	PromotionRule CandidatePromotionRule
+}
+
+// String returns a string representation of the CandidateDatabaseInstance struct
+func (cdi CandidateDatabaseInstance) String() string {
+	return fmt.Sprintf("%s:%d %s", cdi.Hostname, cdi.Port, cdi.PromotionRule)
 }
 
 // BulkReadCandidateDatabaseInstance returns a slice of

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -614,6 +614,36 @@ func ReadInstanceClusterAttributes(instance *Instance) (err error) {
 	return nil
 }
 
+// BulkReadInstance returns a list of all instances from the database
+// - hostname:port is good enough
+func BulkReadInstance() ([](*InstanceKey), error) {
+	var instances [](*InstanceKey)
+
+	// table scan - I know.
+	query := `
+SELECT	hostname, port
+FROM	database_instance
+`
+
+	err := db.QueryOrchestrator(query, nil, func(m sqlutils.RowMap) error {
+		instanceKey := &InstanceKey{
+			Hostname: m.GetString("hostname"),
+			Port:     m.GetInt("port"),
+		}
+		instances = append(instances, instanceKey)
+
+		log.Debugf("BulkReadInstance: %+v", instanceKey)
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return instances, nil
+}
+
 func ReadInstancePromotionRule(instance *Instance) (err error) {
 	if config.Config.DatabaselessMode__experimental {
 		return nil


### PR DESCRIPTION
API end points are:
    /api/bulk-instances       - provide a list of known hostnames
    /api/bulk-promotion-rules - show configured promotion rules

This simplifies comparing orchestrator state with external systems which know intended state
of the servers so that we can then adjust promotion rules inside orchestrator more easily.