### PR TITLE
Add support for -c show-resolve-hosts and -c show-unresolve-hosts

### DIFF
--- a/go/app/cli.go
+++ b/go/app/cli.go
@@ -1397,6 +1397,14 @@ func Cli(command string, strict bool, instance string, destination string, owner
 
 			fmt.Printf("%s\n", strings.Join(asciiPromotionRules, "\n"))
 		}
+	case registerCliCommand("show-resolve-hosts", "Meta, internal", `Show the content of the hostname_resolve table. Generally used for debugging`):
+		{
+			inst.ShowAllHostnameResolves()
+		}
+	case registerCliCommand("show-unresolve-hosts", "Meta, internal", `Show the content of the hostname_unresolve table. Generally used for debugging`):
+		{
+			inst.ShowAllHostnameUnresolves()
+		}
 		// Help
 	case "help":
 		{

--- a/go/inst/resolve.go
+++ b/go/inst/resolve.go
@@ -33,6 +33,11 @@ type HostnameResolve struct {
 	resolvedHostname string
 }
 
+type HostnameUnresolve struct {
+	hostname           string
+	unresolvedHostname string
+}
+
 func init() {
 	if config.Config.ExpiryHostnameResolvesMinutes < 1 {
 		config.Config.ExpiryHostnameResolvesMinutes = 1

--- a/go/inst/resolve_dao.go
+++ b/go/inst/resolve_dao.go
@@ -17,6 +17,8 @@
 package inst
 
 import (
+	"fmt"
+
 	"github.com/outbrain/golib/log"
 	"github.com/outbrain/golib/sqlutils"
 	"github.com/outbrain/orchestrator/go/config"
@@ -101,6 +103,7 @@ func ReadResolvedHostname(hostname string) (string, error) {
 	return resolvedHostname, err
 }
 
+// readAllHostnameResolves returns the content of the hostname_resolve table
 func readAllHostnameResolves() ([]HostnameResolve, error) {
 	res := []HostnameResolve{}
 	query := `
@@ -122,6 +125,49 @@ func readAllHostnameResolves() ([]HostnameResolve, error) {
 		log.Errore(err)
 	}
 	return res, err
+}
+
+// print a string list of all the hostname_resolve table entries
+func ShowAllHostnameResolves() {
+	res, err := readAllHostnameResolves()
+	if err == nil {
+		for _, r := range res{
+			fmt.Printf("%s %s\n", r.hostname, r.resolvedHostname)
+		}
+	}
+}
+
+// readAllHostnameUnresolves returns the content of the hostname_unresolve table
+func readAllHostnameUnresolves() ([]HostnameUnresolve, error) {
+	unres := []HostnameUnresolve{}
+	query := `
+		select
+			hostname,
+			unresolved_hostname
+		from
+			hostname_unresolve
+		`
+	err := db.QueryOrchestratorRowsMap(query, func(m sqlutils.RowMap) error {
+		hostnameUnresolve := HostnameUnresolve{hostname: m.GetString("hostname"), unresolvedHostname: m.GetString("unresolved_hostname")}
+
+		unres = append(unres, hostnameUnresolve)
+		return nil
+	})
+
+	if err != nil {
+		log.Errore(err)
+	}
+	return unres, err
+}
+
+// print a string list of all the hostname_unresolve table entries
+func ShowAllHostnameUnresolves() {
+	res, err := readAllHostnameUnresolves()
+	if err == nil {
+		for _, r := range res{
+			fmt.Printf("%s %s\n", r.hostname, r.unresolvedHostname)
+		}
+	}
 }
 
 // readUnresolvedHostname reverse-reads hostname resolve. It returns a hostname which matches given pattern and resovles to resolvedHostname,


### PR DESCRIPTION
This is mainly used for debugging and also for external scripts to
check the state in the database without accessing it directly.