### PR TITLE
indicating github.com/github/orchestrator

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+# orchestrator upstream has moved
+
+**NOTE**: `orchestrator` development is now active on https://github.com/github/orchestrator, where Issues and Pull Requests are accepted.
+
+This repository is no longer the upstream and latest version of `orchestrator`.
+
+Please submit your Issue at https://github.com/github/orchestrator/issues/new

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+# orchestrator upstream has moved
+
+**NOTE**: `orchestrator` development is now active on https://github.com/github/orchestrator, where Issues and Pull Requests are accepted.
+
+This repository is no longer the upstream and latest version of `orchestrator`.
+
+Please submit your Pull Request with the https://github.com/github/orchestrator repository.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# orchestrator upstream has moved
+
+**NOTE**: `orchestrator` development is now active on https://github.com/github/orchestrator, where Issues and Pull Requests are accepted.
+
+This repository is no longer the upstream and latest version of `orchestrator`.
+
+---
+
 orchestrator [[Manual]](https://github.com/outbrain/orchestrator/wiki/Orchestrator-Manual)
 ============
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **NOTE**: `orchestrator` development is now active on https://github.com/github/orchestrator, where Issues and Pull Requests are accepted.
 
-This repository is no longer the upstream and latest version of `orchestrator`.
+This repository is no longer the upstream and latest version of `orchestrator`. 
+
+The documentation in this repository is not up-to-date.
 
 ---
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -1,3 +1,10 @@
+# orchestrator upstream has moved
+
+**NOTE**: `orchestrator` development is now active on https://github.com/github/orchestrator, where Issues and Pull Requests are accepted.
+
+This repository is no longer the upstream and latest version of `orchestrator`.
+
+---
 ### Who should use orchestrator?
 
 DBAs and ops who have more than a mere single-master-single-slave replication topology.

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -4,6 +4,8 @@
 
 This repository is no longer the upstream and latest version of `orchestrator`.
 
+The documentation in this repository is not up-to-date.
+
 ---
 
 ### Who should use orchestrator?

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -5,6 +5,7 @@
 This repository is no longer the upstream and latest version of `orchestrator`.
 
 ---
+
 ### Who should use orchestrator?
 
 DBAs and ops who have more than a mere single-master-single-slave replication topology.

--- a/doc/Home.md
+++ b/doc/Home.md
@@ -1,3 +1,10 @@
+# orchestrator upstream has moved
+
+**NOTE**: `orchestrator` development is now active on https://github.com/github/orchestrator, where Issues and Pull Requests are accepted.
+
+This repository is no longer the upstream and latest version of `orchestrator`.
+
+---
 Welcome to the _orchestrator_ wiki!
 
 * [Manual](Orchestrator-Manual)

--- a/doc/Home.md
+++ b/doc/Home.md
@@ -4,6 +4,8 @@
 
 This repository is no longer the upstream and latest version of `orchestrator`.
 
+The documentation in this repository is not up-to-date.
+
 ---
 Welcome to the _orchestrator_ wiki!
 

--- a/doc/Orchestrator-Manual.md
+++ b/doc/Orchestrator-Manual.md
@@ -1,3 +1,11 @@
+# orchestrator upstream has moved
+
+**NOTE**: `orchestrator` development is now active on https://github.com/github/orchestrator, where Issues and Pull Requests are accepted.
+
+This repository is no longer the upstream and latest version of `orchestrator`.
+
+---
+
 [Table of Contents](#toc)
 
 ## About

--- a/doc/Orchestrator-Manual.md
+++ b/doc/Orchestrator-Manual.md
@@ -4,6 +4,8 @@
 
 This repository is no longer the upstream and latest version of `orchestrator`.
 
+The documentation in this repository is not up-to-date.
+
 ---
 
 [Table of Contents](#toc)

--- a/doc/Orchestrator-deployment.md
+++ b/doc/Orchestrator-deployment.md
@@ -4,6 +4,8 @@
 
 This repository is no longer the upstream and latest version of `orchestrator`.
 
+The documentation in this repository is not up-to-date.
+
 ---
 This text discusses deployment options for _orchestrator_.
 

--- a/doc/Orchestrator-deployment.md
+++ b/doc/Orchestrator-deployment.md
@@ -1,3 +1,10 @@
+# orchestrator upstream has moved
+
+**NOTE**: `orchestrator` development is now active on https://github.com/github/orchestrator, where Issues and Pull Requests are accepted.
+
+This repository is no longer the upstream and latest version of `orchestrator`.
+
+---
 This text discusses deployment options for _orchestrator_.
 
 It is assumed you already know how to install _orchestrator_ on a production machine and how to configure it with a backend database. It is also assumed you have configured your MySQL servers to allow connections from _orchestrator_.

--- a/doc/Orchestrator-first-steps.md
+++ b/doc/Orchestrator-first-steps.md
@@ -4,6 +4,8 @@
 
 This repository is no longer the upstream and latest version of `orchestrator`.
 
+The documentation in this repository is not up-to-date.
+
 ---
 You have _Orchestrator_ installed and deployed. What can you do with it?
 

--- a/doc/Orchestrator-first-steps.md
+++ b/doc/Orchestrator-first-steps.md
@@ -1,3 +1,10 @@
+# orchestrator upstream has moved
+
+**NOTE**: `orchestrator` development is now active on https://github.com/github/orchestrator, where Issues and Pull Requests are accepted.
+
+This repository is no longer the upstream and latest version of `orchestrator`.
+
+---
 You have _Orchestrator_ installed and deployed. What can you do with it?
 
 A walk through common commands, mostly on the CLI side

--- a/doc/Orchestrator-for-developers.md
+++ b/doc/Orchestrator-for-developers.md
@@ -1,3 +1,10 @@
+# orchestrator upstream has moved
+
+**NOTE**: `orchestrator` development is now active on https://github.com/github/orchestrator, where Issues and Pull Requests are accepted.
+
+This repository is no longer the upstream and latest version of `orchestrator`.
+
+---
 _Orchestrator_ is open source and accepts pull requests.
 
 If you would like to build _orchestrator_ on your own machine, or eventually submit PRs, follow this guide.

--- a/doc/Orchestrator-for-developers.md
+++ b/doc/Orchestrator-for-developers.md
@@ -4,6 +4,8 @@
 
 This repository is no longer the upstream and latest version of `orchestrator`.
 
+The documentation in this repository is not up-to-date.
+
 ---
 _Orchestrator_ is open source and accepts pull requests.
 

--- a/doc/Orchestrator-high-availability.md
+++ b/doc/Orchestrator-high-availability.md
@@ -1,3 +1,10 @@
+# orchestrator upstream has moved
+
+**NOTE**: `orchestrator` development is now active on https://github.com/github/orchestrator, where Issues and Pull Requests are accepted.
+
+This repository is no longer the upstream and latest version of `orchestrator`.
+
+---
 ## Orchestrator High Availability
 
 _Orchestrator_ makes your MySQL topologies available, but what makes _orchestrator_ highly available?

--- a/doc/Orchestrator-high-availability.md
+++ b/doc/Orchestrator-high-availability.md
@@ -4,6 +4,8 @@
 
 This repository is no longer the upstream and latest version of `orchestrator`.
 
+The documentation in this repository is not up-to-date.
+
 ---
 ## Orchestrator High Availability
 


### PR DESCRIPTION
Upstream is now https://github.com/github/orchestrator

This repository will not be synced and will not be kept up-to-date.